### PR TITLE
Switch for reading certain JSON files

### DIFF
--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -122,12 +122,19 @@ class Output:
         if parse:
             self.parse()
 
-    def parse(self) -> None:
+    def parse(self, read_prop_json: bool = True, read_gbw_json: bool = True) -> None:
         """
         Create property- and gbw-JSON file (according to `do_create_property_json` and `self.do_create_gbw_json`)
         and parse them.
-        """
+        Skips the parsing for the gbw or prop json file when the respective bool is false. It defaults to true
 
+        Parameters
+        ----------
+        read_prop_json: bool
+            Whether or not to read the property JSON file
+        read_gbw_json: bool
+            Whether or not to read the gbw JSON file
+        """
         # // Create JSONs files
         if self.do_create_gbw_json:
             self.create_gbw_json()
@@ -135,17 +142,18 @@ class Output:
             self.create_property_json()
 
         # // PARSE JSONS
-        self.gbw_json_data = self._process_json_file(self.gbw_json_file)
-        self.property_json_data = self._process_json_file(self.property_json_file)
-
-        # > `property_json_data` needs to be set
-        if self.do_version_check:
-            self.check_version()
-
         # // Property JSON
-        self.results_properties = PropertyResults(**self.property_json_data)
+        if read_prop_json:
+            self.property_json_data = self._process_json_file(self.property_json_file)
+            # > Check in property json whether version fits:
+            if self.do_version_check:
+                self.check_version()
+            self.results_properties = PropertyResults(**self.property_json_data)
+
         # // GBW JSON file
-        self.results_gbw = GbwResults(**self.gbw_json_data)
+        if read_gbw_json:
+            self.gbw_json_data = self._process_json_file(self.gbw_json_file)
+            self.results_gbw = GbwResults(**self.gbw_json_data)        
 
         # > Redump JSON files
         if self.do_redump_jsons:

--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -130,9 +130,9 @@ class Output:
 
         Parameters
         ----------
-        read_prop_json: bool
+        read_prop_json: bool, default: True
             Whether or not to read the property JSON file
-        read_gbw_json: bool
+        read_gbw_json: bool, default: True
             Whether or not to read the gbw JSON file
         """
         # // Create JSONs files
@@ -149,6 +149,9 @@ class Output:
             if self.do_version_check:
                 self.check_version()
             self.results_properties = PropertyResults(**self.property_json_data)
+        else:
+            if self.do_version_check:
+                warn("No version check possible.")
 
         # // GBW JSON file
         if read_gbw_json:

--- a/src/opi/output/models/json/property/properties/calc_info.py
+++ b/src/opi/output/models/json/property/properties/calc_info.py
@@ -43,7 +43,7 @@ class CalcInfo(GetItem):
     numofelectrons: StrictNonNegativeInt | None = None
     numoffcelectrons: StrictNonNegativeInt | None = None
     numofcorrelectrons: StrictNonNegativeInt | None = None
-    numofbasisfuncts: StrictPositiveInt | None = None
+    numofbasisfuncts: StrictNonNegativeInt | None = None
     numofauxcbasisfuncts: StrictNonNegativeInt | None = None
     numofauxjbasisfuncts: StrictNonNegativeInt | None = None
     numofauxjkbasisfuncts: StrictNonNegativeInt | None = None


### PR DESCRIPTION
## Feature
Introducing two optional switches to the `parse()` function to switch off the reading of the JSON-property and JSON-gbw file. This becomes important when no gbw files are created by ORCA, e.g., when using a force field or external methods via wrapper script. The switches are optional and per default `True`. 

## Usage
When using the `parse()` function of the output object, set the respective variable `False`. Variable names are:
- `read_prop_json` for JSON-property file
- `read_gbw_json` for JSON-gbw file

## Additional changes
As not reading the JSON-gbw file causes the `numofbasisfuncts` to be 0, I changed the `StrictPositiveInt` check to `StrictNonNegativeInt`.

Closes #18 