### PR TITLE
DOCS: added how to cite page, modified versions dropdown

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: "If you use this software, please cite it as below."
 authors:
 - given-names: "FACCTs GmbH"
 title: "OPI"
-version: v1.0.0
+version: v1.0
 doi: 10.5281/zenodo.15688425
 date-released: 2025-06-17
 url: "https://github.com/faccts/opi"

--- a/docs/contents/how_to_cite.md
+++ b/docs/contents/how_to_cite.md
@@ -1,0 +1,31 @@
+
+# How To Cite
+
+If you used OPI, please cite the respective version you used. 
+
+:::{admonition} **OPI Reference**
+:class: tip
+FACCTs GmbH. OPI (Version v1.0). https://github.com/faccts/opi. DOI: 10.5281/zenodo.15688425
+:::
+
+You can adapt the citation layouts given below accordingly.
+
+```{code-block} text
+:caption: BibTeX
+
+@software{opi_v1.0,
+  author       = {{FACCTs GmbH}},
+  title        = {OPI},
+  version      = {v1.0},
+  doi          = {10.5281/zenodo.15688425},
+  url          = {https://github.com/faccts/opi},
+}
+```
+
+```{literalinclude} ../../CITATION.cff
+:language: yaml
+:caption: CITATION.cff
+```
+
+
+

--- a/docs/contents/versions.md
+++ b/docs/contents/versions.md
@@ -5,5 +5,6 @@
 :maxdepth: 1
 :caption: Versions
 
-1.0.0 <https://www.faccts.de/docs/opi/1.0/docs/>
+1.0 <https://www.faccts.de/docs/opi/1.0/docs/>
 Nightly Build <https://www.faccts.de/docs/opi/nightly/docs/>
+Overview <https://www.faccts.de/docs#opi>

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ regarding individual and known issues with ORCA itself.
 :maxdepth: 2
 
 contents/versions
+contents/how_to_cite
 contents/install
 contents/api/index
 ```


### PR DESCRIPTION
- Added how_to_cite.md as a citation guide to the web documentation
- Updated CITATION.cff to make use of vX.Y instead of vX.Y.Z
- Modified the versions sidebar tab to use vX.Y instead of vX.Y.Z and added link to docs overview
- closes #36 