### PR TITLE
Convert comments for simple keywords to docstrings

### DIFF
--- a/examples/exmp025_goat/job.py
+++ b/examples/exmp025_goat/job.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from opi.core import Calculator
 from opi.input.blocks import BlockGoat
-from opi.input.simple_keywords import Sqm, Task
+from opi.input.simple_keywords import Sqm, Goat
 from opi.input.structures import Structure
 
 if __name__ == "__main__":
@@ -15,7 +15,7 @@ if __name__ == "__main__":
 
     calc = Calculator(basename="job", working_dir=wd)
     calc.structure = Structure.from_xyz("inp.xyz")
-    calc.input.add_simple_keywords(Sqm.GFN2_XTB, Task.GOAT)
+    calc.input.add_simple_keywords(Sqm.GFN2_XTB, Goat.GOAT)
     calc.input.add_blocks(BlockGoat(maxiter=128, explore=True))
     calc.input.ncores = 4
 

--- a/src/opi/input/simple_keywords/approximation.py
+++ b/src/opi/input/simple_keywords/approximation.py
@@ -7,90 +7,59 @@ __all__ = ("Approximation",)
 
 
 class Approximation(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Approximation.
-
-    Attributes
-    ----------
-    CLUSTERALL : SimpleKeyword
-        Cluster all grids.
-    COSXCLUSTERALL : SimpleKeyword
-        Cluster cosx grid.
-    COSJXC : SimpleKeyword
-        Fast but blurry DFT.
-    FMM : SimpleKeyword
-        Use FFM approximation.
-    FROZENCORE : SimpleKeyword
-        Frozen core approx. in correlated WFT.
-    NOFROZENCORE : SimpleKeyword
-        Do not use frozen core approximation.
-    RI_BUPO_J : SimpleKeyword
-        Use BUPO approximation.
-    NOBUPO : SimpleKeyword
-        Do not use BUPO approximation.
-    NOCOSX : SimpleKeyword
-        Do not use cosx.
-    RCSINGLESFOCK : SimpleKeyword
-        Use COSX for Fock like single terms in CC.
-    NORCSINGLESFOCK : SimpleKeyword
-        Do not use COSX for Fock like single terms in CC.
-    RI : SimpleKeyword
-        Use RI.
-    NORI : SimpleKeyword
-        Do not use RI.
-    RIJCOSX : SimpleKeyword
-        Approximation for two-electron integrals.
-    NORIJCOSX : SimpleKeyword
-        Approximation for two-electron integrals.
-    RIJKSINGLESFOCK : SimpleKeyword
-        Use RIJK for Fock like single terms in CC.
-    NORIJKSINGLESFOCK : SimpleKeyword
-        Do not use RIJK for Fock like single terms in CC.
-    USESFITTING : SimpleKeyword
-        Use overlap fitting in cosx.
-    NOSFITTING : SimpleKeyword
-        Do not use overlap fitting in cosx
-    SPLITRIJ : SimpleKeyword
-        Approximation for two-electron integrals
-    NOSPLITRIJ : SimpleKeyword
-        Approximation for two-electron integrals
-    RIAO : SimpleKeyword
-        Approximation for two-electron integrals
-    RICOSJ : SimpleKeyword
-        Approximation for two-electron integrals
-    RICOSJX : SimpleKeyword
-        Approximation for two-electron integrals
-    RIJK : SimpleKeyword
-        Approximation for two-electron integrals
-    RIJONX : SimpleKeyword
-        Approximation for two-electron integrals
-    RIJXC : SimpleKeyword
-        Approximation for two-electron integrals
-    """
+    """Enum to store all simple keywords of type Approximation."""
 
     CLUSTERALL = SimpleKeyword("clusterall")
+    """SimpleKeyword: Cluster all grids."""
     COSXCLUSTERALL = SimpleKeyword("cosxclusterall")
+    """SimpleKeyword: Cluster cosx grid."""
     COSJXC = SimpleKeyword("cosjxc")
+    """SimpleKeyword: Fast but blurry DFT."""
     FMM = SimpleKeyword("fmm")
+    """SimpleKeyword: Use FFM approximation."""
     FROZENCORE = SimpleKeyword("frozencore")
+    """SimpleKeyword: Frozen core approx. in correlated WFT."""
     NOFROZENCORE = SimpleKeyword("nofrozencore")
+    """SimpleKeyword: Do not use frozen core approximation."""
     RI_BUPO_J = SimpleKeyword("ri-bupo/j")
+    """SimpleKeyword: Use BUPO approximation."""
     NOBUPO = SimpleKeyword("nobupo")
+    """SimpleKeyword: Do not use BUPO approximation."""
     NOCOSX = SimpleKeyword("nocosx")
+    """SimpleKeyword: Do not use cosx."""
     RCSINGLESFOCK = SimpleKeyword("rcsinglesfock")
+    """SimpleKeyword: Use COSX for Fock like single terms in CC."""
     NORCSINGLESFOCK = SimpleKeyword("norcsinglesfock")
+    """SimpleKeyword: Do not use COSX for Fock like single terms in CC."""
     RI = SimpleKeyword("ri")
+    """SimpleKeyword: Use RI."""
     NORI = SimpleKeyword("nori")
+    """SimpleKeyword: Do not use RI."""
     RIJCOSX = SimpleKeyword("rijcosx")
+    """SimpleKeyword: Approximation for two-electron integrals."""
     NORIJCOSX = SimpleKeyword("norijcosx")
+    """SimpleKeyword: Approximation for two-electron integrals."""
     RIJKSINGLESFOCK = SimpleKeyword("rijksinglesfock")
+    """SimpleKeyword: Use RIJK for Fock like single terms in CC."""
     NORIJKSINGLESFOCK = SimpleKeyword("norijksinglesfock")
+    """SimpleKeyword: Do not use RIJK for Fock like single terms in CC."""
     USESFITTING = SimpleKeyword("usesfitting")
+    """SimpleKeyword: Use overlap fitting in cosx."""
     NOSFITTING = SimpleKeyword("nosfitting")
+    """SimpleKeyword: Do not use overlap fitting in cosx."""
     SPLITRIJ = SimpleKeyword("splitrij")
+    """SimpleKeyword: Approximation for two-electron integrals."""
     NOSPLITRIJ = SimpleKeyword("nosplitrij")
+    """SimpleKeyword: Approximation for two-electron integrals."""
     RIAO = SimpleKeyword("riao")
+    """SimpleKeyword: Approximation for two-electron integrals."""
     RICOSJ = SimpleKeyword("ricosj")
+    """SimpleKeyword: Approximation for two-electron integrals."""
     RICOSJX = SimpleKeyword("ricosjx")
+    """SimpleKeyword: Approximation for two-electron integrals."""
     RIJK = SimpleKeyword("rijk")
+    """SimpleKeyword: Approximation for two-electron integrals."""
     RIJONX = SimpleKeyword("rijonx")
+    """SimpleKeyword: Approximation for two-electron integrals."""
     RIJXC = SimpleKeyword("rijxc")
+    """SimpleKeyword: Approximation for two-electron integrals."""

--- a/src/opi/input/simple_keywords/approximation.py
+++ b/src/opi/input/simple_keywords/approximation.py
@@ -12,45 +12,43 @@ class Approximation(SimpleKeywordBox):
     Attributes
     ----------
     CLUSTERALL : SimpleKeyword
-        cluster all grids
+        Cluster all grids.
     COSXCLUSTERALL : SimpleKeyword
-        cluster cosx grid
+        Cluster cosx grid.
     COSJXC : SimpleKeyword
-        fast but blurry DFT
+        Fast but blurry DFT.
     FMM : SimpleKeyword
-        Use FFM approximation
+        Use FFM approximation.
     FROZENCORE : SimpleKeyword
-        Frozen core approx. in correlated WFT
+        Frozen core approx. in correlated WFT.
     NOFROZENCORE : SimpleKeyword
-        do not use frozen core approximation
+        Do not use frozen core approximation.
     RI_BUPO_J : SimpleKeyword
-        Use BUPO
+        Use BUPO approximation.
     NOBUPO : SimpleKeyword
-        Do not use BUPO
+        Do not use BUPO approximation.
     NOCOSX : SimpleKeyword
-        Do not use cosx
+        Do not use cosx.
     RCSINGLESFOCK : SimpleKeyword
-        Use COSX for Fock like single terms in CC
+        Use COSX for Fock like single terms in CC.
     NORCSINGLESFOCK : SimpleKeyword
-        Do not use COSX for Fock like single terms in CC
+        Do not use COSX for Fock like single terms in CC.
     RI : SimpleKeyword
-        Use RI
+        Use RI.
     NORI : SimpleKeyword
-        Do not use RI
+        Do not use RI.
     RIJCOSX : SimpleKeyword
-        Approximation for two-electron integrals
+        Approximation for two-electron integrals.
     NORIJCOSX : SimpleKeyword
-        Approximation for two-electron integrals
+        Approximation for two-electron integrals.
     RIJKSINGLESFOCK : SimpleKeyword
-        Use RIJK for Fock like single terms in CC
+        Use RIJK for Fock like single terms in CC.
     NORIJKSINGLESFOCK : SimpleKeyword
-        Do not use RIJK for Fock like single terms in CC
+        Do not use RIJK for Fock like single terms in CC.
     USESFITTING : SimpleKeyword
-        Approximation
+        Use overlap fitting in cosx.
     NOSFITTING : SimpleKeyword
         Do not use overlap fitting in cosx
-    SPLITJ : SimpleKeyword
-        Approximation for two-electron integrals
     SPLITRIJ : SimpleKeyword
         Approximation for two-electron integrals
     NOSPLITRIJ : SimpleKeyword
@@ -88,7 +86,6 @@ class Approximation(SimpleKeywordBox):
     NORIJKSINGLESFOCK = SimpleKeyword("norijksinglesfock")
     USESFITTING = SimpleKeyword("usesfitting")
     NOSFITTING = SimpleKeyword("nosfitting")
-    SPLITJ = SimpleKeyword("splitj")
     SPLITRIJ = SimpleKeyword("splitrij")
     NOSPLITRIJ = SimpleKeyword("nosplitrij")
     RIAO = SimpleKeyword("riao")

--- a/src/opi/input/simple_keywords/approximation.py
+++ b/src/opi/input/simple_keywords/approximation.py
@@ -7,37 +7,93 @@ __all__ = ("Approximation",)
 
 
 class Approximation(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Approximation"""
+    """Enum to store all simple keywords of type Approximation.
 
-    CLUSTERALL = SimpleKeyword("clusterall")  # cluster all grids
-    COSXCLUSTERALL = SimpleKeyword("cosxclusterall")  # cluster cosx grid
-    COSJXC = SimpleKeyword("cosjxc")  # fast but blurry DFT
-    FMM = SimpleKeyword("fmm")  # Use FFM approximation
-    FROZENCORE = SimpleKeyword("frozencore")  # Frozen core approx. in correlated WFT
-    NOFROZENCORE = SimpleKeyword("nofrozencore")  # do not use frozen core approximation
-    RI_BUPO_J = SimpleKeyword("ri-bupo/j")  # Use BUPO
-    NOBUPO = SimpleKeyword("nobupo")  # Do not use BUPO
-    NOCOSX = SimpleKeyword("nocosx")  # Do not use cosx
-    RCSINGLESFOCK = SimpleKeyword("rcsinglesfock")  # Use COSX for Fock like single terms in CC
-    NORCSINGLESFOCK = SimpleKeyword(
-        "norcsinglesfock"
-    )  # Do not use COSX for Fock like single terms in CC
-    RI = SimpleKeyword("ri")  # Use RI
-    NORI = SimpleKeyword("nori")  # Do not use RI
-    RIJCOSX = SimpleKeyword("rijcosx")  # Approximation for two-electron integrals
-    NORIJCOSX = SimpleKeyword("norijcosx")  # Approximation for two-electron integrals
-    RIJKSINGLESFOCK = SimpleKeyword("rijksinglesfock")  # Use RIJK for Fock like single terms in CC
-    NORIJKSINGLESFOCK = SimpleKeyword(
-        "norijksinglesfock"
-    )  # Do not use RIJK for Fock like single terms in CC
+    Attributes
+    ----------
+    CLUSTERALL : SimpleKeyword
+        cluster all grids
+    COSXCLUSTERALL : SimpleKeyword
+        cluster cosx grid
+    COSJXC : SimpleKeyword
+        fast but blurry DFT
+    FMM : SimpleKeyword
+        Use FFM approximation
+    FROZENCORE : SimpleKeyword
+        Frozen core approx. in correlated WFT
+    NOFROZENCORE : SimpleKeyword
+        do not use frozen core approximation
+    RI_BUPO_J : SimpleKeyword
+        Use BUPO
+    NOBUPO : SimpleKeyword
+        Do not use BUPO
+    NOCOSX : SimpleKeyword
+        Do not use cosx
+    RCSINGLESFOCK : SimpleKeyword
+        Use COSX for Fock like single terms in CC
+    NORCSINGLESFOCK : SimpleKeyword
+        Do not use COSX for Fock like single terms in CC
+    RI : SimpleKeyword
+        Use RI
+    NORI : SimpleKeyword
+        Do not use RI
+    RIJCOSX : SimpleKeyword
+        Approximation for two-electron integrals
+    NORIJCOSX : SimpleKeyword
+        Approximation for two-electron integrals
+    RIJKSINGLESFOCK : SimpleKeyword
+        Use RIJK for Fock like single terms in CC
+    NORIJKSINGLESFOCK : SimpleKeyword
+        Do not use RIJK for Fock like single terms in CC
+    USESFITTING : SimpleKeyword
+        Approximation
+    NOSFITTING : SimpleKeyword
+        Do not use overlap fitting in cosx
+    SPLITJ : SimpleKeyword
+        Approximation for two-electron integrals
+    SPLITRIJ : SimpleKeyword
+        Approximation for two-electron integrals
+    NOSPLITRIJ : SimpleKeyword
+        Approximation for two-electron integrals
+    RIAO : SimpleKeyword
+        Approximation for two-electron integrals
+    RICOSJ : SimpleKeyword
+        Approximation for two-electron integrals
+    RICOSJX : SimpleKeyword
+        Approximation for two-electron integrals
+    RIJK : SimpleKeyword
+        Approximation for two-electron integrals
+    RIJONX : SimpleKeyword
+        Approximation for two-electron integrals
+    RIJXC : SimpleKeyword
+        Approximation for two-electron integrals
+    """
+
+    CLUSTERALL = SimpleKeyword("clusterall")
+    COSXCLUSTERALL = SimpleKeyword("cosxclusterall")
+    COSJXC = SimpleKeyword("cosjxc")
+    FMM = SimpleKeyword("fmm")
+    FROZENCORE = SimpleKeyword("frozencore")
+    NOFROZENCORE = SimpleKeyword("nofrozencore")
+    RI_BUPO_J = SimpleKeyword("ri-bupo/j")
+    NOBUPO = SimpleKeyword("nobupo")
+    NOCOSX = SimpleKeyword("nocosx")
+    RCSINGLESFOCK = SimpleKeyword("rcsinglesfock")
+    NORCSINGLESFOCK = SimpleKeyword("norcsinglesfock")
+    RI = SimpleKeyword("ri")
+    NORI = SimpleKeyword("nori")
+    RIJCOSX = SimpleKeyword("rijcosx")
+    NORIJCOSX = SimpleKeyword("norijcosx")
+    RIJKSINGLESFOCK = SimpleKeyword("rijksinglesfock")
+    NORIJKSINGLESFOCK = SimpleKeyword("norijksinglesfock")
     USESFITTING = SimpleKeyword("usesfitting")
-    NOSFITTING = SimpleKeyword("nosfitting")  # Do not use overlap fitting in cosx
-    SPLITJ = SimpleKeyword("splitj")  # Approximation for two-electron integrals
-    SPLITRIJ = SimpleKeyword("splitrij")  # Approximation for two-electron integrals
-    NOSPLITRIJ = SimpleKeyword("nosplitrij")  # Approximation for two-electron integrals
-    RIAO = SimpleKeyword("riao")  # Approximation for two-electron integrals
-    RICOSJ = SimpleKeyword("ricosj")  # Approximation for two-electron integrals
-    RICOSJX = SimpleKeyword("ricosjx")  # Approximation for two-electron integrals
-    RIJK = SimpleKeyword("rijk")  # Approximation for two-electron integrals
-    RIJONX = SimpleKeyword("rijonx")  # Approximation for two-electron integrals
-    RIJXC = SimpleKeyword("rijxc")  # Approximation for two-electron integrals
+    NOSFITTING = SimpleKeyword("nosfitting")
+    SPLITJ = SimpleKeyword("splitj")
+    SPLITRIJ = SimpleKeyword("splitrij")
+    NOSPLITRIJ = SimpleKeyword("nosplitrij")
+    RIAO = SimpleKeyword("riao")
+    RICOSJ = SimpleKeyword("ricosj")
+    RICOSJX = SimpleKeyword("ricosjx")
+    RIJK = SimpleKeyword("rijk")
+    RIJONX = SimpleKeyword("rijonx")
+    RIJXC = SimpleKeyword("rijxc")

--- a/src/opi/input/simple_keywords/atomic_charge.py
+++ b/src/opi/input/simple_keywords/atomic_charge.py
@@ -12,55 +12,51 @@ class AtomicCharge(SimpleKeywordBox):
     Attributes
     ----------
     AIM : SimpleKeyword
-        AtomicCharge
+        Produce a WFN file for usage in AIM analysis.
     ALLPOP : SimpleKeyword
-        AtomicCharge
+        Turns on all population analyses.
     CHELPG : SimpleKeyword
-        AtomicCharge
+        Calculate CHELPG charges.
     CHELPG_LARGE : SimpleKeyword
-        AtomicCharge
+        Calculate CHELPG charges with larger grids.
     DENSITYANALYSIS : SimpleKeyword
-        AtomicCharge
+        Perform density analysis for fragments.
     FMOPOP : SimpleKeyword
-        AtomicCharge
-    FMOPOPULATIONS : SimpleKeyword
-        AtomicCharge
+        Request population analyses for HOMO and LUMO.
     HIRSHFELD : SimpleKeyword
-        AtomicCharge
+        Calculate Hirshfeld charges.
     LOEWDIN : SimpleKeyword
-        AtomicCharge
+        Calculate Loewdin charges.
     MAYER : SimpleKeyword
-        AtomicCharge
+        Calculate Mayer charges.
     MBIS : SimpleKeyword
-        AtomicCharge
+        Calculate Minimal Basis Iterative Stockholder (MBIS) charges.
     MULLIKEN : SimpleKeyword
-        AtomicCharge
+        Calculate Mulliken charges.
     NOAIM : SimpleKeyword
-        AtomicCharge
+        Do not create a WFN file for usage in AIM analysis.
     NOFMOPOP : SimpleKeyword
-        AtomicCharge
-    NOFMOPOPULATIONS : SimpleKeyword
-        AtomicCharge
+        Do not request population analyses for HOMO and LUMO.
     NOHIRSHFELD : SimpleKeyword
-        AtomicCharge
+        Do not calculate Hirshfeld charges.
     NOLOEWDIN : SimpleKeyword
-        AtomicCharge
+        Do not calculate Loewdin charges.
     NOMAYER : SimpleKeyword
-        AtomicCharge
+        Do not calculate Mayer charges.
     NOMBIS : SimpleKeyword
-        AtomicCharge
+        Do not calculate Minimal Basis Iterative Stockholder (MBIS) charges.
     NOMULLIKEN : SimpleKeyword
-        AtomicCharge
+        Do not calculate Mulliken charges.
     NONPA : SimpleKeyword
-        AtomicCharge
+        Do not calculate NPA charges.
     NOPOP : SimpleKeyword
-        AtomicCharge
+        Turns off all population analyses.
     NOREDUCEDPOP : SimpleKeyword
-        AtomicCharge
+        Do not print Loewdin reduced orb.pop per MO.
     NPA : SimpleKeyword
-        AtomicCharge
+        Calculate NPA charges (requires the nbo package).
     REDUCEDPOP : SimpleKeyword
-        AtomicCharge
+        Print Loewdin reduced orb.pop per MO.
     """
 
     AIM = SimpleKeyword("aim")
@@ -77,7 +73,6 @@ class AtomicCharge(SimpleKeywordBox):
     MULLIKEN = SimpleKeyword("mulliken")
     NOAIM = SimpleKeyword("noaim")
     NOFMOPOP = SimpleKeyword("nofmopop")
-    NOFMOPOPULATIONS = SimpleKeyword("nofmopopulations")
     NOHIRSHFELD = SimpleKeyword("nohirshfeld")
     NOLOEWDIN = SimpleKeyword("noloewdin")
     NOMAYER = SimpleKeyword("nomayer")

--- a/src/opi/input/simple_keywords/atomic_charge.py
+++ b/src/opi/input/simple_keywords/atomic_charge.py
@@ -7,79 +7,52 @@ __all__ = ("AtomicCharge",)
 
 
 class AtomicCharge(SimpleKeywordBox):
-    """Enum to store all simple keywords of type AtomicCharge.
-
-    Attributes
-    ----------
-    AIM : SimpleKeyword
-        Produce a WFN file for usage in AIM analysis.
-    ALLPOP : SimpleKeyword
-        Turns on all population analyses.
-    CHELPG : SimpleKeyword
-        Calculate CHELPG charges.
-    CHELPG_LARGE : SimpleKeyword
-        Calculate CHELPG charges with larger grids.
-    DENSITYANALYSIS : SimpleKeyword
-        Perform density analysis for fragments.
-    FMOPOP : SimpleKeyword
-        Request population analyses for HOMO and LUMO.
-    HIRSHFELD : SimpleKeyword
-        Calculate Hirshfeld charges.
-    LOEWDIN : SimpleKeyword
-        Calculate Loewdin charges.
-    MAYER : SimpleKeyword
-        Calculate Mayer charges.
-    MBIS : SimpleKeyword
-        Calculate Minimal Basis Iterative Stockholder (MBIS) charges.
-    MULLIKEN : SimpleKeyword
-        Calculate Mulliken charges.
-    NOAIM : SimpleKeyword
-        Do not create a WFN file for usage in AIM analysis.
-    NOFMOPOP : SimpleKeyword
-        Do not request population analyses for HOMO and LUMO.
-    NOHIRSHFELD : SimpleKeyword
-        Do not calculate Hirshfeld charges.
-    NOLOEWDIN : SimpleKeyword
-        Do not calculate Loewdin charges.
-    NOMAYER : SimpleKeyword
-        Do not calculate Mayer charges.
-    NOMBIS : SimpleKeyword
-        Do not calculate Minimal Basis Iterative Stockholder (MBIS) charges.
-    NOMULLIKEN : SimpleKeyword
-        Do not calculate Mulliken charges.
-    NONPA : SimpleKeyword
-        Do not calculate NPA charges.
-    NOPOP : SimpleKeyword
-        Turns off all population analyses.
-    NOREDUCEDPOP : SimpleKeyword
-        Do not print Loewdin reduced orb.pop per MO.
-    NPA : SimpleKeyword
-        Calculate NPA charges (requires the nbo package).
-    REDUCEDPOP : SimpleKeyword
-        Print Loewdin reduced orb.pop per MO.
-    """
+    """Enum to store all simple keywords of type AtomicCharge."""
 
     AIM = SimpleKeyword("aim")
+    """SimpleKeyword: Produce a WFN file for usage in AIM analysis."""
     ALLPOP = SimpleKeyword("allpop")
+    """SimpleKeyword: Turns on all population analyses."""
     CHELPG = SimpleKeyword("chelpg")
+    """SimpleKeyword: Calculate CHELPG charges."""
     CHELPG_LARGE = SimpleKeyword("chelpg(large)")
+    """SimpleKeyword: Calculate CHELPG charges with larger grids."""
     DENSITYANALYSIS = SimpleKeyword("densityanalysis")
+    """SimpleKeyword: Perform density analysis for fragments."""
     FMOPOP = SimpleKeyword("fmopop")
+    """SimpleKeyword: Request population analyses for HOMO and LUMO."""
     FMOPOPULATIONS = SimpleKeyword("fmopopulations")
     HIRSHFELD = SimpleKeyword("hirshfeld")
+    """SimpleKeyword: Calculate Hirshfeld charges."""
     LOEWDIN = SimpleKeyword("loewdin")
+    """SimpleKeyword: Calculate Loewdin charges."""
     MAYER = SimpleKeyword("mayer")
+    """SimpleKeyword: Calculate Mayer charges."""
     MBIS = SimpleKeyword("mbis")
+    """SimpleKeyword: Calculate Minimal Basis Iterative Stockholder (MBIS) charges."""
     MULLIKEN = SimpleKeyword("mulliken")
+    """SimpleKeyword: Calculate Mulliken charges."""
     NOAIM = SimpleKeyword("noaim")
+    """SimpleKeyword: Do not create a WFN file for usage in AIM analysis."""
     NOFMOPOP = SimpleKeyword("nofmopop")
+    """SimpleKeyword: Do not request population analyses for HOMO and LUMO."""
     NOHIRSHFELD = SimpleKeyword("nohirshfeld")
+    """SimpleKeyword: Do not calculate Hirshfeld charges."""
     NOLOEWDIN = SimpleKeyword("noloewdin")
+    """SimpleKeyword: Do not calculate Loewdin charges."""
     NOMAYER = SimpleKeyword("nomayer")
+    """SimpleKeyword: Do not calculate Mayer charges."""
     NOMBIS = SimpleKeyword("nombis")
+    """SimpleKeyword: Do not calculate Minimal Basis Iterative Stockholder (MBIS) charges."""
     NOMULLIKEN = SimpleKeyword("nomulliken")
+    """SimpleKeyword: Do not calculate Mulliken charges."""
     NONPA = SimpleKeyword("nonpa")
+    """SimpleKeyword: Do not calculate NPA charges."""
     NOPOP = SimpleKeyword("nopop")
+    """SimpleKeyword: Turns off all population analyses."""
     NOREDUCEDPOP = SimpleKeyword("noreducedpop")
+    """SimpleKeyword: Do not print Loewdin reduced orb.pop per MO."""
     NPA = SimpleKeyword("npa")
+    """SimpleKeyword: Calculate NPA charges (requires the nbo package)."""
     REDUCEDPOP = SimpleKeyword("reducedpop")
+    """SimpleKeyword: Print Loewdin reduced orb.pop per MO."""

--- a/src/opi/input/simple_keywords/atomic_charge.py
+++ b/src/opi/input/simple_keywords/atomic_charge.py
@@ -7,7 +7,61 @@ __all__ = ("AtomicCharge",)
 
 
 class AtomicCharge(SimpleKeywordBox):
-    """Enum to store all simple keywords of type AtomicCharge"""
+    """Enum to store all simple keywords of type AtomicCharge.
+
+    Attributes
+    ----------
+    AIM : SimpleKeyword
+        AtomicCharge
+    ALLPOP : SimpleKeyword
+        AtomicCharge
+    CHELPG : SimpleKeyword
+        AtomicCharge
+    CHELPG_LARGE : SimpleKeyword
+        AtomicCharge
+    DENSITYANALYSIS : SimpleKeyword
+        AtomicCharge
+    FMOPOP : SimpleKeyword
+        AtomicCharge
+    FMOPOPULATIONS : SimpleKeyword
+        AtomicCharge
+    HIRSHFELD : SimpleKeyword
+        AtomicCharge
+    LOEWDIN : SimpleKeyword
+        AtomicCharge
+    MAYER : SimpleKeyword
+        AtomicCharge
+    MBIS : SimpleKeyword
+        AtomicCharge
+    MULLIKEN : SimpleKeyword
+        AtomicCharge
+    NOAIM : SimpleKeyword
+        AtomicCharge
+    NOFMOPOP : SimpleKeyword
+        AtomicCharge
+    NOFMOPOPULATIONS : SimpleKeyword
+        AtomicCharge
+    NOHIRSHFELD : SimpleKeyword
+        AtomicCharge
+    NOLOEWDIN : SimpleKeyword
+        AtomicCharge
+    NOMAYER : SimpleKeyword
+        AtomicCharge
+    NOMBIS : SimpleKeyword
+        AtomicCharge
+    NOMULLIKEN : SimpleKeyword
+        AtomicCharge
+    NONPA : SimpleKeyword
+        AtomicCharge
+    NOPOP : SimpleKeyword
+        AtomicCharge
+    NOREDUCEDPOP : SimpleKeyword
+        AtomicCharge
+    NPA : SimpleKeyword
+        AtomicCharge
+    REDUCEDPOP : SimpleKeyword
+        AtomicCharge
+    """
 
     AIM = SimpleKeyword("aim")
     ALLPOP = SimpleKeyword("allpop")

--- a/src/opi/input/simple_keywords/aux_basis_set.py
+++ b/src/opi/input/simple_keywords/aux_basis_set.py
@@ -7,225 +7,149 @@ __all__ = ("AuxBasisSet",)
 
 
 class AuxBasisSet(SimpleKeywordBox):
-    """Enum to store all simple keywords of type AuxBasisSet.
-
-    Attributes
-    ----------
-    AUTOAUX : SimpleKeyword
-        Can be used as replacement for any AuxBasisSet
-    AUTOAUXTRIM : SimpleKeyword
-        trims the autoaux basis
-    AUG_CC_PV5Z_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PV5Z_JK : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PV6Z_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PVDZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PVDZ_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PVQZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PVQZ_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PVQZ_JK : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PVTZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PVTZ_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PVTZ_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PVTZ_JK : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PWCV5Z_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PWCVDZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PWCVDZ_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PWCVQZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PWCVQZ_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PWCVTZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    AUG_CC_PWCVTZ_C : SimpleKeyword
-        AuxBasisSet
-    CC_PCVDZ_F12_MP2FIT : SimpleKeyword
-        AuxBasisSet
-    CC_PCVQZ_F12_MP2FIT : SimpleKeyword
-        AuxBasisSet
-    CC_PCVTZ_F12_MP2FIT : SimpleKeyword
-        AuxBasisSet
-    CC_PV5Z_C : SimpleKeyword
-        AuxBasisSet
-    CC_PV5Z_JK : SimpleKeyword
-        AuxBasisSet
-    CC_PV6Z_C : SimpleKeyword
-        AuxBasisSet
-    CC_PVDZ_F12_MP2FIT : SimpleKeyword
-        AuxBasisSet
-    CC_PVDZ_PP_F12_MP2FIT : SimpleKeyword
-        AuxBasisSet
-    CC_PVDZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    CC_PVDZ_C : SimpleKeyword
-        AuxBasisSet
-    CC_PVQZ_F12_MP2FIT : SimpleKeyword
-        AuxBasisSet
-    CC_PVQZ_PP_F12_MP2FIT : SimpleKeyword
-        AuxBasisSet
-    CC_PVQZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    CC_PVQZ_C : SimpleKeyword
-        AuxBasisSet
-    CC_PVQZ_JK : SimpleKeyword
-        AuxBasisSet
-    CC_PVTZ_F12_MP2FIT : SimpleKeyword
-        AuxBasisSet
-    CC_PVTZ_PP_F12_MP2FIT : SimpleKeyword
-        AuxBasisSet
-    CC_PVTZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    CC_PVTZ_C : SimpleKeyword
-        AuxBasisSet
-    CC_PVTZ_JK : SimpleKeyword
-        AuxBasisSet
-    CC_PWCV5Z_C : SimpleKeyword
-        AuxBasisSet
-    CC_PWCVDZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    CC_PWCVDZ_C : SimpleKeyword
-        AuxBasisSet
-    CC_PWCVQZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    CC_PWCVQZ_C : SimpleKeyword
-        AuxBasisSet
-    CC_PWCVTZ_PP_C : SimpleKeyword
-        AuxBasisSet
-    CC_PWCVTZ_C : SimpleKeyword
-        AuxBasisSet
-    DEF_J : SimpleKeyword
-        AuxBasisSet
-    DEF2_MSVP_J : SimpleKeyword
-        AuxBasisSet
-    DEF2_MTZVP_J : SimpleKeyword
-        AuxBasisSet
-    DEF2_MTZVPP_J : SimpleKeyword
-        AuxBasisSet
-    DEF2_QZVPP_C : SimpleKeyword
-        AuxBasisSet
-    DEF2_QZVPPD_C : SimpleKeyword
-        AuxBasisSet
-    DEF2_SVP_C : SimpleKeyword
-        AuxBasisSet
-    DEF2_SVPD_C : SimpleKeyword
-        AuxBasisSet
-    DEF2_TZVP_C : SimpleKeyword
-        AuxBasisSet
-    DEF2_TZVPD_C : SimpleKeyword
-        AuxBasisSet
-    DEF2_TZVPP_C : SimpleKeyword
-        AuxBasisSet
-    DEF2_TZVPPD_C : SimpleKeyword
-        AuxBasisSet
-    DEF2_J : SimpleKeyword
-        AuxBasisSet
-    DEF2_JK : SimpleKeyword
-        AuxBasisSet
-    DEF2_JKSMALL : SimpleKeyword
-        AuxBasisSet
-    DGAUSS_A1_J : SimpleKeyword
-        AuxBasisSet
-    DGAUSS_A2_J : SimpleKeyword
-        AuxBasisSet
-    MIN_J : SimpleKeyword
-        AuxBasisSet
-    SARC_J : SimpleKeyword
-        AuxBasisSet
-    SARC2_DKH_QZV_JK : SimpleKeyword
-        AuxBasisSet
-    SARC2_DKH_QZVP_JK : SimpleKeyword
-        AuxBasisSet
-    SARC2_ZORA_QZV_JK : SimpleKeyword
-        AuxBasisSet
-    SARC2_ZORA_QZVP_JK : SimpleKeyword
-        AuxBasisSet
-    X2C_J : SimpleKeyword
-        AuxBasisSet
-    """
+    """Enum to store all simple keywords of type AuxBasisSet."""
 
     AUTOAUX = SimpleKeyword("autoaux")
+    """SimpleKeyword: Can be used as replacement for any AuxBasisSet."""
     AUTOAUXTRIM = SimpleKeyword("autoauxtrim")
+    """SimpleKeyword: trims the autoaux basis."""
     AUG_CC_PV5Z_C = SimpleKeyword("aug-cc-pv5z/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PV5Z_JK = SimpleKeyword("aug-cc-pv5z/jk")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PV6Z_C = SimpleKeyword("aug-cc-pv6z/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PVDZ_PP_C = SimpleKeyword("aug-cc-pvdz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PVDZ_C = SimpleKeyword("aug-cc-pvdz/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PVQZ_PP_C = SimpleKeyword("aug-cc-pvqz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PVQZ_C = SimpleKeyword("aug-cc-pvqz/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PVQZ_JK = SimpleKeyword("aug-cc-pvqz/jk")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PVTZ_PP_C = SimpleKeyword("aug-cc-pvtz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PVTZ_C = SimpleKeyword("aug-cc-pvtz/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PVTZ_C = SimpleKeyword("aug-cc-pvtz/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PVTZ_JK = SimpleKeyword("aug-cc-pvtz/jk")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PWCV5Z_C = SimpleKeyword("aug-cc-pwcv5z/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PWCVDZ_PP_C = SimpleKeyword("aug-cc-pwcvdz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PWCVDZ_C = SimpleKeyword("aug-cc-pwcvdz/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PWCVQZ_PP_C = SimpleKeyword("aug-cc-pwcvqz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PWCVQZ_C = SimpleKeyword("aug-cc-pwcvqz/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PWCVTZ_PP_C = SimpleKeyword("aug-cc-pwcvtz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     AUG_CC_PWCVTZ_C = SimpleKeyword("aug-cc-pwcvtz/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PCVDZ_F12_MP2FIT = SimpleKeyword("cc-pcvdz-f12-mp2fit")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PCVQZ_F12_MP2FIT = SimpleKeyword("cc-pcvqz-f12-mp2fit")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PCVTZ_F12_MP2FIT = SimpleKeyword("cc-pcvtz-f12-mp2fit")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PV5Z_C = SimpleKeyword("cc-pv5z/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PV5Z_JK = SimpleKeyword("cc-pv5z/jk")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PV6Z_C = SimpleKeyword("cc-pv6z/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVDZ_F12_MP2FIT = SimpleKeyword("cc-pvdz-f12-mp2fit")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVDZ_PP_F12_MP2FIT = SimpleKeyword("cc-pvdz-pp-f12-mp2fit")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVDZ_PP_C = SimpleKeyword("cc-pvdz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVDZ_C = SimpleKeyword("cc-pvdz/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVQZ_F12_MP2FIT = SimpleKeyword("cc-pvqz-f12-mp2fit")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVQZ_PP_F12_MP2FIT = SimpleKeyword("cc-pvqz-pp-f12-mp2fit")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVQZ_PP_C = SimpleKeyword("cc-pvqz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVQZ_C = SimpleKeyword("cc-pvqz/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVQZ_JK = SimpleKeyword("cc-pvqz/jk")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVTZ_F12_MP2FIT = SimpleKeyword("cc-pvtz-f12-mp2fit")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVTZ_PP_F12_MP2FIT = SimpleKeyword("cc-pvtz-pp-f12-mp2fit")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVTZ_PP_C = SimpleKeyword("cc-pvtz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVTZ_C = SimpleKeyword("cc-pvtz/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PVTZ_JK = SimpleKeyword("cc-pvtz/jk")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PWCV5Z_C = SimpleKeyword("cc-pwcv5z/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PWCVDZ_PP_C = SimpleKeyword("cc-pwcvdz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PWCVDZ_C = SimpleKeyword("cc-pwcvdz/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PWCVQZ_PP_C = SimpleKeyword("cc-pwcvqz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PWCVQZ_C = SimpleKeyword("cc-pwcvqz/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PWCVTZ_PP_C = SimpleKeyword("cc-pwcvtz-pp/c")
+    """SimpleKeyword: AuxBasisSet."""
     CC_PWCVTZ_C = SimpleKeyword("cc-pwcvtz/c")
+    """SimpleKeyword: AuxBasisSet."""
     DEF_J = SimpleKeyword("def/j")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_MSVP_J = SimpleKeyword("def2-msvp/j")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_MTZVP_J = SimpleKeyword("def2-mtzvp/j")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_MTZVPP_J = SimpleKeyword("def2-mtzvpp/j")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_QZVPP_C = SimpleKeyword("def2-qzvpp/c")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_QZVPPD_C = SimpleKeyword("def2-qzvppd/c")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_SVP_C = SimpleKeyword("def2-svp/c")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_SVPD_C = SimpleKeyword("def2-svpd/c")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_TZVP_C = SimpleKeyword("def2-tzvp/c")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_TZVPD_C = SimpleKeyword("def2-tzvpd/c")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_TZVPP_C = SimpleKeyword("def2-tzvpp/c")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_TZVPPD_C = SimpleKeyword("def2-tzvppd/c")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_J = SimpleKeyword("def2/j")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_JK = SimpleKeyword("def2/jk")
+    """SimpleKeyword: AuxBasisSet."""
     DEF2_JKSMALL = SimpleKeyword("def2/jksmall")
+    """SimpleKeyword: AuxBasisSet."""
     DGAUSS_A1_J = SimpleKeyword("dgauss-a1/j")
+    """SimpleKeyword: AuxBasisSet."""
     DGAUSS_A2_J = SimpleKeyword("dgauss-a2/j")
+    """SimpleKeyword: AuxBasisSet."""
     MIN_J = SimpleKeyword("min/j")
+    """SimpleKeyword: AuxBasisSet."""
     SARC_J = SimpleKeyword("sarc/j")
+    """SimpleKeyword: AuxBasisSet."""
     SARC2_DKH_QZV_JK = SimpleKeyword("sarc2-dkh-qzv/jk")
+    """SimpleKeyword: AuxBasisSet."""
     SARC2_DKH_QZVP_JK = SimpleKeyword("sarc2-dkh-qzvp/jk")
+    """SimpleKeyword: AuxBasisSet."""
     SARC2_ZORA_QZV_JK = SimpleKeyword("sarc2-zora-qzv/jk")
+    """SimpleKeyword: AuxBasisSet."""
     SARC2_ZORA_QZVP_JK = SimpleKeyword("sarc2-zora-qzvp/jk")
+    """SimpleKeyword: AuxBasisSet."""
     X2C_J = SimpleKeyword("x2c/j")
+    """SimpleKeyword: AuxBasisSet."""

--- a/src/opi/input/simple_keywords/aux_basis_set.py
+++ b/src/opi/input/simple_keywords/aux_basis_set.py
@@ -7,10 +7,158 @@ __all__ = ("AuxBasisSet",)
 
 
 class AuxBasisSet(SimpleKeywordBox):
-    """Enum to store all simple keywords of type AuxBasisSet"""
+    """Enum to store all simple keywords of type AuxBasisSet.
 
-    AUTOAUX = SimpleKeyword("autoaux")  # Can be used as replacement for any AuxBasisSet
-    AUTOAUXTRIM = SimpleKeyword("autoauxtrim")  # trims the autoaux basis
+    Attributes
+    ----------
+    AUTOAUX : SimpleKeyword
+        Can be used as replacement for any AuxBasisSet
+    AUTOAUXTRIM : SimpleKeyword
+        trims the autoaux basis
+    AUG_CC_PV5Z_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PV5Z_JK : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PV6Z_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PVDZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PVDZ_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PVQZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PVQZ_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PVQZ_JK : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PVTZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PVTZ_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PVTZ_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PVTZ_JK : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PWCV5Z_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PWCVDZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PWCVDZ_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PWCVQZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PWCVQZ_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PWCVTZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    AUG_CC_PWCVTZ_C : SimpleKeyword
+        AuxBasisSet
+    CC_PCVDZ_F12_MP2FIT : SimpleKeyword
+        AuxBasisSet
+    CC_PCVQZ_F12_MP2FIT : SimpleKeyword
+        AuxBasisSet
+    CC_PCVTZ_F12_MP2FIT : SimpleKeyword
+        AuxBasisSet
+    CC_PV5Z_C : SimpleKeyword
+        AuxBasisSet
+    CC_PV5Z_JK : SimpleKeyword
+        AuxBasisSet
+    CC_PV6Z_C : SimpleKeyword
+        AuxBasisSet
+    CC_PVDZ_F12_MP2FIT : SimpleKeyword
+        AuxBasisSet
+    CC_PVDZ_PP_F12_MP2FIT : SimpleKeyword
+        AuxBasisSet
+    CC_PVDZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    CC_PVDZ_C : SimpleKeyword
+        AuxBasisSet
+    CC_PVQZ_F12_MP2FIT : SimpleKeyword
+        AuxBasisSet
+    CC_PVQZ_PP_F12_MP2FIT : SimpleKeyword
+        AuxBasisSet
+    CC_PVQZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    CC_PVQZ_C : SimpleKeyword
+        AuxBasisSet
+    CC_PVQZ_JK : SimpleKeyword
+        AuxBasisSet
+    CC_PVTZ_F12_MP2FIT : SimpleKeyword
+        AuxBasisSet
+    CC_PVTZ_PP_F12_MP2FIT : SimpleKeyword
+        AuxBasisSet
+    CC_PVTZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    CC_PVTZ_C : SimpleKeyword
+        AuxBasisSet
+    CC_PVTZ_JK : SimpleKeyword
+        AuxBasisSet
+    CC_PWCV5Z_C : SimpleKeyword
+        AuxBasisSet
+    CC_PWCVDZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    CC_PWCVDZ_C : SimpleKeyword
+        AuxBasisSet
+    CC_PWCVQZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    CC_PWCVQZ_C : SimpleKeyword
+        AuxBasisSet
+    CC_PWCVTZ_PP_C : SimpleKeyword
+        AuxBasisSet
+    CC_PWCVTZ_C : SimpleKeyword
+        AuxBasisSet
+    DEF_J : SimpleKeyword
+        AuxBasisSet
+    DEF2_MSVP_J : SimpleKeyword
+        AuxBasisSet
+    DEF2_MTZVP_J : SimpleKeyword
+        AuxBasisSet
+    DEF2_MTZVPP_J : SimpleKeyword
+        AuxBasisSet
+    DEF2_QZVPP_C : SimpleKeyword
+        AuxBasisSet
+    DEF2_QZVPPD_C : SimpleKeyword
+        AuxBasisSet
+    DEF2_SVP_C : SimpleKeyword
+        AuxBasisSet
+    DEF2_SVPD_C : SimpleKeyword
+        AuxBasisSet
+    DEF2_TZVP_C : SimpleKeyword
+        AuxBasisSet
+    DEF2_TZVPD_C : SimpleKeyword
+        AuxBasisSet
+    DEF2_TZVPP_C : SimpleKeyword
+        AuxBasisSet
+    DEF2_TZVPPD_C : SimpleKeyword
+        AuxBasisSet
+    DEF2_J : SimpleKeyword
+        AuxBasisSet
+    DEF2_JK : SimpleKeyword
+        AuxBasisSet
+    DEF2_JKSMALL : SimpleKeyword
+        AuxBasisSet
+    DGAUSS_A1_J : SimpleKeyword
+        AuxBasisSet
+    DGAUSS_A2_J : SimpleKeyword
+        AuxBasisSet
+    MIN_J : SimpleKeyword
+        AuxBasisSet
+    SARC_J : SimpleKeyword
+        AuxBasisSet
+    SARC2_DKH_QZV_JK : SimpleKeyword
+        AuxBasisSet
+    SARC2_DKH_QZVP_JK : SimpleKeyword
+        AuxBasisSet
+    SARC2_ZORA_QZV_JK : SimpleKeyword
+        AuxBasisSet
+    SARC2_ZORA_QZVP_JK : SimpleKeyword
+        AuxBasisSet
+    X2C_J : SimpleKeyword
+        AuxBasisSet
+    """
+
+    AUTOAUX = SimpleKeyword("autoaux")
+    AUTOAUXTRIM = SimpleKeyword("autoauxtrim")
     AUG_CC_PV5Z_C = SimpleKeyword("aug-cc-pv5z/c")
     AUG_CC_PV5Z_JK = SimpleKeyword("aug-cc-pv5z/jk")
     AUG_CC_PV6Z_C = SimpleKeyword("aug-cc-pv6z/c")

--- a/src/opi/input/simple_keywords/avas.py
+++ b/src/opi/input/simple_keywords/avas.py
@@ -7,11 +7,27 @@ __all__ = ("Avas",)
 
 
 class Avas(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Avas"""
+    """Enum to store all simple keywords of type Avas.
 
-    AVAS_DOUBLE_D = SimpleKeyword("avas(double-d)")  # CASSCF initial guess
-    AVAS_DOUBLE_DS = SimpleKeyword("avas(double-ds)")  # CASSCF initial guess
-    AVAS_DOUBLE_F = SimpleKeyword("avas(double-f)")  # CASSCF initial guess
-    AVAS_VALENCE_D = SimpleKeyword("avas(valence-d)")  # CASSCF initial guess
-    AVAS_VALENCE_DS = SimpleKeyword("avas(valence-ds)")  # CASSCF initial guess
-    AVAS_VALENCE_F = SimpleKeyword("avas(valence-f)")  # CASSCF initial guess
+    Attributes
+    ----------
+    AVAS_DOUBLE_D : SimpleKeyword
+        CASSCF initial guess
+    AVAS_DOUBLE_DS : SimpleKeyword
+        CASSCF initial guess
+    AVAS_DOUBLE_F : SimpleKeyword
+        CASSCF initial guess
+    AVAS_VALENCE_D : SimpleKeyword
+        CASSCF initial guess
+    AVAS_VALENCE_DS : SimpleKeyword
+        CASSCF initial guess
+    AVAS_VALENCE_F : SimpleKeyword
+        CASSCF initial guess
+    """
+
+    AVAS_DOUBLE_D = SimpleKeyword("avas(double-d)")
+    AVAS_DOUBLE_DS = SimpleKeyword("avas(double-ds)")
+    AVAS_DOUBLE_F = SimpleKeyword("avas(double-f)")
+    AVAS_VALENCE_D = SimpleKeyword("avas(valence-d)")
+    AVAS_VALENCE_DS = SimpleKeyword("avas(valence-ds)")
+    AVAS_VALENCE_F = SimpleKeyword("avas(valence-f)")

--- a/src/opi/input/simple_keywords/avas.py
+++ b/src/opi/input/simple_keywords/avas.py
@@ -7,27 +7,17 @@ __all__ = ("Avas",)
 
 
 class Avas(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Avas.
-
-    Attributes
-    ----------
-    AVAS_DOUBLE_D : SimpleKeyword
-        CASSCF initial guess
-    AVAS_DOUBLE_DS : SimpleKeyword
-        CASSCF initial guess
-    AVAS_DOUBLE_F : SimpleKeyword
-        CASSCF initial guess
-    AVAS_VALENCE_D : SimpleKeyword
-        CASSCF initial guess
-    AVAS_VALENCE_DS : SimpleKeyword
-        CASSCF initial guess
-    AVAS_VALENCE_F : SimpleKeyword
-        CASSCF initial guess
-    """
+    """Enum to store all simple keywords of type Avas."""
 
     AVAS_DOUBLE_D = SimpleKeyword("avas(double-d)")
+    """SimpleKeyword: CASSCF initial guess."""
     AVAS_DOUBLE_DS = SimpleKeyword("avas(double-ds)")
+    """SimpleKeyword: CASSCF initial guess."""
     AVAS_DOUBLE_F = SimpleKeyword("avas(double-f)")
+    """SimpleKeyword: CASSCF initial guess."""
     AVAS_VALENCE_D = SimpleKeyword("avas(valence-d)")
+    """SimpleKeyword: CASSCF initial guess."""
     AVAS_VALENCE_DS = SimpleKeyword("avas(valence-ds)")
+    """SimpleKeyword: CASSCF initial guess."""
     AVAS_VALENCE_F = SimpleKeyword("avas(valence-f)")
+    """SimpleKeyword: CASSCF initial guess."""

--- a/src/opi/input/simple_keywords/basis_set.py
+++ b/src/opi/input/simple_keywords/basis_set.py
@@ -7,1473 +7,981 @@ __all__ = ("BasisSet",)
 
 
 class BasisSet(SimpleKeywordBox):
-    """Enum to store all simple keywords of type BasisSet.
-
-    Attributes
-    ----------
-    G3_21G : SimpleKeyword
-        BasisSet
-    G3_21GSP : SimpleKeyword
-        BasisSet
-    G4_22GSP : SimpleKeyword
-        BasisSet
-    G6_31PLUSPLUSG_2D_2P : SimpleKeyword
-        BasisSet
-    G6_31PLUSPLUSG_2D_P : SimpleKeyword
-        BasisSet
-    G6_31PLUSPLUSG_2DF_2P : SimpleKeyword
-        BasisSet
-    G6_31PLUSPLUSG_2DF_2PD : SimpleKeyword
-        BasisSet
-    G6_31PLUSPLUSG_D_P : SimpleKeyword
-        BasisSet
-    G6_31PLUSPLUSGSTARSTAR : SimpleKeyword
-        BasisSet
-    G6_31PLUSG_2D_2P : SimpleKeyword
-        BasisSet
-    G6_31PLUSG_2D_P : SimpleKeyword
-        BasisSet
-    G6_31PLUSG_2D : SimpleKeyword
-        BasisSet
-    G6_31PLUSG_2DF_2P : SimpleKeyword
-        BasisSet
-    G6_31PLUSG_2DF_2PD : SimpleKeyword
-        BasisSet
-    G6_31PLUSG_2DF : SimpleKeyword
-        BasisSet
-    G6_31PLUSG_D_P : SimpleKeyword
-        BasisSet
-    G6_31PLUSG_D : SimpleKeyword
-        BasisSet
-    G6_31PLUSGSTAR : SimpleKeyword
-        BasisSet
-    G6_31PLUSGSTARSTAR : SimpleKeyword
-        BasisSet
-    G6_311PLUSPLUSG_2D_2P : SimpleKeyword
-        BasisSet
-    G6_311PLUSPLUSG_2D_P : SimpleKeyword
-        BasisSet
-    G6_311PLUSPLUSG_2DF_2P : SimpleKeyword
-        BasisSet
-    G6_311PLUSPLUSG_2DF_2PD : SimpleKeyword
-        BasisSet
-    G6_311PLUSPLUSG_3DF_3PD : SimpleKeyword
-        BasisSet
-    G6_311PLUSPLUSG_D_P : SimpleKeyword
-        BasisSet
-    G6_311PLUSPLUSGSTARSTAR : SimpleKeyword
-        BasisSet
-    G6_311PLUSG_2D_2P : SimpleKeyword
-        BasisSet
-    G6_311PLUSG_2D_P : SimpleKeyword
-        BasisSet
-    G6_311PLUSG_2D : SimpleKeyword
-        BasisSet
-    G6_311PLUSG_2DF_2P : SimpleKeyword
-        BasisSet
-    G6_311PLUSG_2DF_2PD : SimpleKeyword
-        BasisSet
-    G6_311PLUSG_2DF : SimpleKeyword
-        BasisSet
-    G6_311PLUSG_3DF_2P : SimpleKeyword
-        BasisSet
-    G6_311PLUSG_3DF_3PD : SimpleKeyword
-        BasisSet
-    G6_311PLUSG_3DF : SimpleKeyword
-        BasisSet
-    G6_311PLUSG_D_P : SimpleKeyword
-        BasisSet
-    G6_311PLUSG_D : SimpleKeyword
-        BasisSet
-    G6_311PLUSGSTAR : SimpleKeyword
-        BasisSet
-    G6_311PLUSGSTARSTAR : SimpleKeyword
-        BasisSet
-    G6_311G : SimpleKeyword
-        BasisSet
-    G6_311G_2D_2P : SimpleKeyword
-        BasisSet
-    G6_311G_2D_P : SimpleKeyword
-        BasisSet
-    G6_311G_2D : SimpleKeyword
-        BasisSet
-    G6_311G_2DF_2P : SimpleKeyword
-        BasisSet
-    G6_311G_2DF_2PD : SimpleKeyword
-        BasisSet
-    G6_311G_2DF : SimpleKeyword
-        BasisSet
-    G6_311G_3DF_3PD : SimpleKeyword
-        BasisSet
-    G6_311G_3DF : SimpleKeyword
-        BasisSet
-    G6_311G_D_P : SimpleKeyword
-        BasisSet
-    G6_311G_D : SimpleKeyword
-        BasisSet
-    G6_311GSTAR : SimpleKeyword
-        BasisSet
-    G6_311GSTARSTAR : SimpleKeyword
-        BasisSet
-    G6_31G : SimpleKeyword
-        BasisSet
-    G6_31G_2D_2P : SimpleKeyword
-        BasisSet
-    G6_31G_2D_P : SimpleKeyword
-        BasisSet
-    G6_31G_2D : SimpleKeyword
-        BasisSet
-    G6_31G_2DF_2P : SimpleKeyword
-        BasisSet
-    G6_31G_2DF_2PD : SimpleKeyword
-        BasisSet
-    G6_31G_2DF : SimpleKeyword
-        BasisSet
-    G6_31G_D_P : SimpleKeyword
-        BasisSet
-    G6_31G_D : SimpleKeyword
-        BasisSet
-    G6_31GSTAR : SimpleKeyword
-        BasisSet
-    G6_31GSTARSTAR : SimpleKeyword
-        BasisSet
-    AHGBS_5 : SimpleKeyword
-        BasisSet
-    AHGBS_7 : SimpleKeyword
-        BasisSet
-    AHGBS_9 : SimpleKeyword
-        BasisSet
-    AHGBSP1_5 : SimpleKeyword
-        BasisSet
-    AHGBSP1_7 : SimpleKeyword
-        BasisSet
-    AHGBSP1_9 : SimpleKeyword
-        BasisSet
-    AHGBSP2_5 : SimpleKeyword
-        BasisSet
-    AHGBSP2_7 : SimpleKeyword
-        BasisSet
-    AHGBSP2_9 : SimpleKeyword
-        BasisSet
-    AHGBSP3_5 : SimpleKeyword
-        BasisSet
-    AHGBSP3_7 : SimpleKeyword
-        BasisSet
-    AHGBSP3_9 : SimpleKeyword
-        BasisSet
-    ANO_PC_0 : SimpleKeyword
-        BasisSet
-    ANO_PC_0_POL : SimpleKeyword
-        BasisSet
-    ANO_PV5Z : SimpleKeyword
-        BasisSet
-    ANO_PV6Z : SimpleKeyword
-        BasisSet
-    ANO_PVDZ : SimpleKeyword
-        BasisSet
-    ANO_PVQZ : SimpleKeyword
-        BasisSet
-    ANO_PVTZ : SimpleKeyword
-        BasisSet
-    ANO_RCC_DZP : SimpleKeyword
-        BasisSet
-    ANO_RCC_FULL : SimpleKeyword
-        BasisSet
-    ANO_RCC_MB : SimpleKeyword
-        BasisSet
-    ANO_RCC_QZP : SimpleKeyword
-        BasisSet
-    ANO_RCC_TZP : SimpleKeyword
-        BasisSet
-    ANO_SZ : SimpleKeyword
-        BasisSet
-    ANO_SZ_DKH_SMALL : SimpleKeyword
-        BasisSet
-    APR_CC_PV_QPLUSD_Z : SimpleKeyword
-        BasisSet
-    AUG_ANO_PV5Z : SimpleKeyword
-        BasisSet
-    AUG_ANO_PVDZ : SimpleKeyword
-        BasisSet
-    AUG_ANO_PVQZ : SimpleKeyword
-        BasisSet
-    AUG_ANO_PVTZ : SimpleKeyword
-        BasisSet
-    AUG_CC_PCV5Z : SimpleKeyword
-        BasisSet
-    AUG_CC_PCV5Z_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PCV6Z : SimpleKeyword
-        BasisSet
-    AUG_CC_PCVDZ : SimpleKeyword
-        BasisSet
-    AUG_CC_PCVDZ_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PCVQZ : SimpleKeyword
-        BasisSet
-    AUG_CC_PCVQZ_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PCVTZ : SimpleKeyword
-        BasisSet
-    AUG_CC_PCVTZ_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PV5_PLUSD_Z : SimpleKeyword
-        BasisSet
-    AUG_CC_PV5Z : SimpleKeyword
-        BasisSet
-    AUG_CC_PV5Z_DK : SimpleKeyword
-        BasisSet
-    AUG_CC_PV5Z_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PV5Z_PP_OPTRI : SimpleKeyword
-        BasisSet
-    AUG_CC_PV6_PLUSD_Z : SimpleKeyword
-        BasisSet
-    AUG_CC_PV6Z : SimpleKeyword
-        BasisSet
-    AUG_CC_PV7Z : SimpleKeyword
-        BasisSet
-    AUG_CC_PVD_PLUSD_Z : SimpleKeyword
-        BasisSet
-    AUG_CC_PVDZ : SimpleKeyword
-        BasisSet
-    AUG_CC_PVDZ_DK : SimpleKeyword
-        BasisSet
-    AUG_CC_PVDZ_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PVDZ_PP_OPTRI : SimpleKeyword
-        BasisSet
-    AUG_CC_PVQ_PLUSD_Z : SimpleKeyword
-        BasisSet
-    AUG_CC_PVQZ : SimpleKeyword
-        BasisSet
-    AUG_CC_PVQZ_DK : SimpleKeyword
-        BasisSet
-    AUG_CC_PVQZ_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PVQZ_PP_OPTRI : SimpleKeyword
-        BasisSet
-    AUG_CC_PVT_PLUSD_Z : SimpleKeyword
-        BasisSet
-    AUG_CC_PVTZ : SimpleKeyword
-        BasisSet
-    AUG_CC_PVTZ_DK : SimpleKeyword
-        BasisSet
-    AUG_CC_PVTZ_J : SimpleKeyword
-        BasisSet
-    AUG_CC_PVTZ_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PVTZ_PP_OPTRI : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCV5Z : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCV5Z_DK : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCV5Z_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCV5Z_PP_OPTRI : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVDZ : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVDZ_DK : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVDZ_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVDZ_PP_OPTRI : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVQZ : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVQZ_DK : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVQZ_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVQZ_PP_OPTRI : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVTZ : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVTZ_DK : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVTZ_PP : SimpleKeyword
-        BasisSet
-    AUG_CC_PWCVTZ_PP_OPTRI : SimpleKeyword
-        BasisSet
-    AUG_PC_0 : SimpleKeyword
-        BasisSet
-    AUG_PC_1 : SimpleKeyword
-        BasisSet
-    AUG_PC_2 : SimpleKeyword
-        BasisSet
-    AUG_PC_3 : SimpleKeyword
-        BasisSet
-    AUG_PC_4 : SimpleKeyword
-        BasisSet
-    AUG_PCH_1 : SimpleKeyword
-        BasisSet
-    AUG_PCH_2 : SimpleKeyword
-        BasisSet
-    AUG_PCH_3 : SimpleKeyword
-        BasisSet
-    AUG_PCH_4 : SimpleKeyword
-        BasisSet
-    AUG_PCJ_0 : SimpleKeyword
-        BasisSet
-    AUG_PCJ_1 : SimpleKeyword
-        BasisSet
-    AUG_PCJ_2 : SimpleKeyword
-        BasisSet
-    AUG_PCJ_3 : SimpleKeyword
-        BasisSet
-    AUG_PCJ_4 : SimpleKeyword
-        BasisSet
-    AUG_PCSEG_0 : SimpleKeyword
-        BasisSet
-    AUG_PCSEG_1 : SimpleKeyword
-        BasisSet
-    AUG_PCSEG_2 : SimpleKeyword
-        BasisSet
-    AUG_PCSEG_3 : SimpleKeyword
-        BasisSet
-    AUG_PCSEG_4 : SimpleKeyword
-        BasisSet
-    AUG_PCSSEG_0 : SimpleKeyword
-        BasisSet
-    AUG_PCSSEG_1 : SimpleKeyword
-        BasisSet
-    AUG_PCSSEG_2 : SimpleKeyword
-        BasisSet
-    AUG_PCSSEG_3 : SimpleKeyword
-        BasisSet
-    AUG_PCSSEG_4 : SimpleKeyword
-        BasisSet
-    AUG_PCX_1 : SimpleKeyword
-        BasisSet
-    AUG_PCX_2 : SimpleKeyword
-        BasisSet
-    AUG_PCX_3 : SimpleKeyword
-        BasisSet
-    AUG_PCX_4 : SimpleKeyword
-        BasisSet
-    CC_PCV5Z : SimpleKeyword
-        BasisSet
-    CC_PCV5Z_PP : SimpleKeyword
-        BasisSet
-    CC_PCV6Z : SimpleKeyword
-        BasisSet
-    CC_PCVDZ : SimpleKeyword
-        BasisSet
-    CC_PCVDZ_F12 : SimpleKeyword
-        BasisSet
-    CC_PCVDZ_F12_OPTRI : SimpleKeyword
-        BasisSet
-    CC_PCVDZ_PP : SimpleKeyword
-        BasisSet
-    CC_PCVQZ : SimpleKeyword
-        BasisSet
-    CC_PCVQZ_F12 : SimpleKeyword
-        BasisSet
-    CC_PCVQZ_F12_OPTRI : SimpleKeyword
-        BasisSet
-    CC_PCVQZ_PP : SimpleKeyword
-        BasisSet
-    CC_PCVTZ : SimpleKeyword
-        BasisSet
-    CC_PCVTZ_F12 : SimpleKeyword
-        BasisSet
-    CC_PCVTZ_F12_OPTRI : SimpleKeyword
-        BasisSet
-    CC_PCVTZ_PP : SimpleKeyword
-        BasisSet
-    CC_PV5_PLUSD_Z : SimpleKeyword
-        BasisSet
-    CC_PV5Z : SimpleKeyword
-        BasisSet
-    CC_PV5Z_DK : SimpleKeyword
-        BasisSet
-    CC_PV5Z_PP : SimpleKeyword
-        BasisSet
-    CC_PV6Z : SimpleKeyword
-        BasisSet
-    CC_PV7Z : SimpleKeyword
-        BasisSet
-    CC_PV8Z : SimpleKeyword
-        BasisSet
-    CC_PVD_PLUSD_Z : SimpleKeyword
-        BasisSet
-    CC_PVDZ : SimpleKeyword
-        BasisSet
-    CC_PVDZ_DK : SimpleKeyword
-        BasisSet
-    CC_PVDZ_DK3 : SimpleKeyword
-        BasisSet
-    CC_PVDZ_F12 : SimpleKeyword
-        BasisSet
-    CC_PVDZ_F12_CABS : SimpleKeyword
-        BasisSet
-    CC_PVDZ_F12_OPTRI : SimpleKeyword
-        BasisSet
-    CC_PVDZ_PP : SimpleKeyword
-        BasisSet
-    CC_PVDZ_PP_F12 : SimpleKeyword
-        BasisSet
-    CC_PVDZ_PP_F12_OPTRI : SimpleKeyword
-        BasisSet
-    CC_PVQ_PLUSD_Z : SimpleKeyword
-        BasisSet
-    CC_PVQZ : SimpleKeyword
-        BasisSet
-    CC_PVQZ_DK : SimpleKeyword
-        BasisSet
-    CC_PVQZ_DK3 : SimpleKeyword
-        BasisSet
-    CC_PVQZ_F12 : SimpleKeyword
-        BasisSet
-    CC_PVQZ_F12_CABS : SimpleKeyword
-        BasisSet
-    CC_PVQZ_F12_OPTRI : SimpleKeyword
-        BasisSet
-    CC_PVQZ_PP : SimpleKeyword
-        BasisSet
-    CC_PVQZ_PP_F12 : SimpleKeyword
-        BasisSet
-    CC_PVQZ_PP_F12_OPTRI : SimpleKeyword
-        BasisSet
-    CC_PVT_PLUSD_Z : SimpleKeyword
-        BasisSet
-    CC_PVTZ : SimpleKeyword
-        BasisSet
-    CC_PVTZ_DK : SimpleKeyword
-        BasisSet
-    CC_PVTZ_DK3 : SimpleKeyword
-        BasisSet
-    CC_PVTZ_F12 : SimpleKeyword
-        BasisSet
-    CC_PVTZ_F12_CABS : SimpleKeyword
-        BasisSet
-    CC_PVTZ_F12_OPTRI : SimpleKeyword
-        BasisSet
-    CC_PVTZ_PP : SimpleKeyword
-        BasisSet
-    CC_PVTZ_PP_F12 : SimpleKeyword
-        BasisSet
-    CC_PVTZ_PP_F12_OPTRI : SimpleKeyword
-        BasisSet
-    CC_PWCV5Z : SimpleKeyword
-        BasisSet
-    CC_PWCV5Z_DK : SimpleKeyword
-        BasisSet
-    CC_PWCV5Z_PP : SimpleKeyword
-        BasisSet
-    CC_PWCVDZ : SimpleKeyword
-        BasisSet
-    CC_PWCVDZ_DK : SimpleKeyword
-        BasisSet
-    CC_PWCVDZ_DK3 : SimpleKeyword
-        BasisSet
-    CC_PWCVDZ_PP : SimpleKeyword
-        BasisSet
-    CC_PWCVQZ : SimpleKeyword
-        BasisSet
-    CC_PWCVQZ_DK : SimpleKeyword
-        BasisSet
-    CC_PWCVQZ_DK3 : SimpleKeyword
-        BasisSet
-    CC_PWCVQZ_PP : SimpleKeyword
-        BasisSet
-    CC_PWCVTZ : SimpleKeyword
-        BasisSet
-    CC_PWCVTZ_DK : SimpleKeyword
-        BasisSet
-    CC_PWCVTZ_DK3 : SimpleKeyword
-        BasisSet
-    CC_PWCVTZ_PP : SimpleKeyword
-        BasisSet
-    CP : SimpleKeyword
-        BasisSet
-    CP_PPP : SimpleKeyword
-        BasisSet
-    CRENBL : SimpleKeyword
-        BasisSet
-    D95 : SimpleKeyword
-        BasisSet
-    D95P : SimpleKeyword
-        BasisSet
-    DEF_SV_P : SimpleKeyword
-        BasisSet
-    DEF_SVP : SimpleKeyword
-        BasisSet
-    DEF_TZVP : SimpleKeyword
-        BasisSet
-    DEF_TZVPP : SimpleKeyword
-        BasisSet
-    DEF2_MSVP : SimpleKeyword
-        BasisSet
-    DEF2_MTZVP : SimpleKeyword
-        BasisSet
-    DEF2_MTZVPP : SimpleKeyword
-        BasisSet
-    DEF2_QZVP : SimpleKeyword
-        BasisSet
-    DEF2_QZVPD : SimpleKeyword
-        BasisSet
-    DEF2_QZVPP : SimpleKeyword
-        BasisSet
-    DEF2_QZVPPD : SimpleKeyword
-        BasisSet
-    DEF2_SV_P : SimpleKeyword
-        BasisSet
-    DEF2_SVP : SimpleKeyword
-        BasisSet
-    DEF2_SVPD : SimpleKeyword
-        BasisSet
-    DEF2_TZVP : SimpleKeyword
-        BasisSet
-    DEF2_TZVP_F : SimpleKeyword
-        BasisSet
-    DEF2_TZVPD : SimpleKeyword
-        BasisSet
-    DEF2_TZVPP : SimpleKeyword
-        BasisSet
-    DEF2_TZVPPD : SimpleKeyword
-        BasisSet
-    DHF_QZVP : SimpleKeyword
-        BasisSet
-    DHF_QZVP_2C : SimpleKeyword
-        BasisSet
-    DHF_QZVPP : SimpleKeyword
-        BasisSet
-    DHF_QZVPP_2C : SimpleKeyword
-        BasisSet
-    DHF_SV_P : SimpleKeyword
-        BasisSet
-    DHF_SV_P_2C : SimpleKeyword
-        BasisSet
-    DHF_SVP : SimpleKeyword
-        BasisSet
-    DHF_SVP_2C : SimpleKeyword
-        BasisSet
-    DHF_TZVP : SimpleKeyword
-        BasisSet
-    DHF_TZVP_2C : SimpleKeyword
-        BasisSet
-    DHF_TZVPP : SimpleKeyword
-        BasisSet
-    DHF_TZVPP_2C : SimpleKeyword
-        BasisSet
-    DKH_DEF2_QZVPP : SimpleKeyword
-        BasisSet
-    DKH_DEF2_SV_P : SimpleKeyword
-        BasisSet
-    DKH_DEF2_SVP : SimpleKeyword
-        BasisSet
-    DKH_DEF2_TZVP : SimpleKeyword
-        BasisSet
-    DKH_DEF2_TZVP_F : SimpleKeyword
-        BasisSet
-    DKH_DEF2_TZVPP : SimpleKeyword
-        BasisSet
-    DKH_MA_DEF2_QZVPP : SimpleKeyword
-        BasisSet
-    DKH_MA_DEF2_SV_P : SimpleKeyword
-        BasisSet
-    DKH_MA_DEF2_SVP : SimpleKeyword
-        BasisSet
-    DKH_MA_DEF2_TZVP : SimpleKeyword
-        BasisSet
-    DKH_MA_DEF2_TZVP_F : SimpleKeyword
-        BasisSet
-    DKH_MA_DEF2_TZVPP : SimpleKeyword
-        BasisSet
-    DKH_QZVP : SimpleKeyword
-        BasisSet
-    DKH_QZVPP : SimpleKeyword
-        BasisSet
-    DKH_SV_P : SimpleKeyword
-        BasisSet
-    DKH_SVP : SimpleKeyword
-        BasisSet
-    DKH_TZV_P : SimpleKeyword
-        BasisSet
-    DKH_TZVP : SimpleKeyword
-        BasisSet
-    DKH_TZVPP : SimpleKeyword
-        BasisSet
-    EPR_II : SimpleKeyword
-        BasisSet
-    EPR_III : SimpleKeyword
-        BasisSet
-    GFN1BASIS : SimpleKeyword
-        BasisSet
-    GFN2BASIS : SimpleKeyword
-        BasisSet
-    HAV_5PLUSD_Z : SimpleKeyword
-        BasisSet
-    HAV_QPLUSD_Z : SimpleKeyword
-        BasisSet
-    HAV_TPLUSD_Z : SimpleKeyword
-        BasisSet
-    HAV5Z_PLUSD : SimpleKeyword
-        BasisSet
-    HAVQZ_PLUSD : SimpleKeyword
-        BasisSet
-    HAVTZ_PLUSD : SimpleKeyword
-        BasisSet
-    HGBS_5 : SimpleKeyword
-        BasisSet
-    HGBS_7 : SimpleKeyword
-        BasisSet
-    HGBS_9 : SimpleKeyword
-        BasisSet
-    HGBSP1_5 : SimpleKeyword
-        BasisSet
-    HGBSP1_7 : SimpleKeyword
-        BasisSet
-    HGBSP1_9 : SimpleKeyword
-        BasisSet
-    HGBSP2_5 : SimpleKeyword
-        BasisSet
-    HGBSP2_7 : SimpleKeyword
-        BasisSet
-    HGBSP2_9 : SimpleKeyword
-        BasisSet
-    HGBSP3_5 : SimpleKeyword
-        BasisSet
-    HGBSP3_7 : SimpleKeyword
-        BasisSet
-    HGBSP3_9 : SimpleKeyword
-        BasisSet
-    IGLO_II : SimpleKeyword
-        BasisSet
-    IGLO_III : SimpleKeyword
-        BasisSet
-    JUL_CC_PV_DPLUSD_Z : SimpleKeyword
-        BasisSet
-    JUL_CC_PV_QPLUSD_Z : SimpleKeyword
-        BasisSet
-    JUL_CC_PV_TPLUSD_Z : SimpleKeyword
-        BasisSet
-    JUN_CC_PV_DPLUSD_Z : SimpleKeyword
-        BasisSet
-    JUN_CC_PV_QPLUSD_Z : SimpleKeyword
-        BasisSet
-    JUN_CC_PV_TPLUSD_Z : SimpleKeyword
-        BasisSet
-    LANL08 : SimpleKeyword
-        BasisSet
-    LANL08_F : SimpleKeyword
-        BasisSet
-    LANL2DZ : SimpleKeyword
-        BasisSet
-    LANL2TZ : SimpleKeyword
-        BasisSet
-    LANL2TZ_F : SimpleKeyword
-        BasisSet
-    M6_31G : SimpleKeyword
-        BasisSet
-    M6_31GSTAR : SimpleKeyword
-        BasisSet
-    MA_DEF_TZVP : SimpleKeyword
-        BasisSet
-    MA_DEF2_MSVP : SimpleKeyword
-        BasisSet
-    MA_DEF2_QZVP : SimpleKeyword
-        BasisSet
-    MA_DEF2_QZVPP : SimpleKeyword
-        BasisSet
-    MA_DEF2_SV_P : SimpleKeyword
-        BasisSet
-    MA_DEF2_SVP : SimpleKeyword
-        BasisSet
-    MA_DEF2_TZVP : SimpleKeyword
-        BasisSet
-    MA_DEF2_TZVP_F : SimpleKeyword
-        BasisSet
-    MA_DEF2_TZVPP : SimpleKeyword
-        BasisSet
-    MA_DKH_DEF2_QZVPP : SimpleKeyword
-        BasisSet
-    MA_DKH_DEF2_SV_P : SimpleKeyword
-        BasisSet
-    MA_DKH_DEF2_SVP : SimpleKeyword
-        BasisSet
-    MA_DKH_DEF2_TZVP : SimpleKeyword
-        BasisSet
-    MA_DKH_DEF2_TZVP_F : SimpleKeyword
-        BasisSet
-    MA_DKH_DEF2_TZVPP : SimpleKeyword
-        BasisSet
-    MA_ZORA_DEF2_QZVPP : SimpleKeyword
-        BasisSet
-    MA_ZORA_DEF2_SV_P : SimpleKeyword
-        BasisSet
-    MA_ZORA_DEF2_SVP : SimpleKeyword
-        BasisSet
-    MA_ZORA_DEF2_TZVP : SimpleKeyword
-        BasisSet
-    MA_ZORA_DEF2_TZVP_F : SimpleKeyword
-        BasisSet
-    MA_ZORA_DEF2_TZVPP : SimpleKeyword
-        BasisSet
-    MAUG_CC_PV_DPLUSD_Z : SimpleKeyword
-        BasisSet
-    MAUG_CC_PV_QPLUSD_Z : SimpleKeyword
-        BasisSet
-    MAUG_CC_PV_TPLUSD_Z : SimpleKeyword
-        BasisSet
-    MAY_CC_PV_QPLUSD_Z : SimpleKeyword
-        BasisSet
-    MAY_CC_PV_TPLUSD_Z : SimpleKeyword
-        BasisSet
-    MIDI : SimpleKeyword
-        BasisSet
-    MINAO : SimpleKeyword
-        BasisSet
-    MINAO_AUTO_PP : SimpleKeyword
-        BasisSet
-    MINI : SimpleKeyword
-        BasisSet
-    MINIS : SimpleKeyword
-        BasisSet
-    MINIX : SimpleKeyword
-        BasisSet
-    OLD_DKH_SV_P : SimpleKeyword
-        BasisSet
-    OLD_DKH_SVP : SimpleKeyword
-        BasisSet
-    OLD_DKH_TZV_P : SimpleKeyword
-        BasisSet
-    OLD_DKH_TZVP : SimpleKeyword
-        BasisSet
-    OLD_DKH_TZVPP : SimpleKeyword
-        BasisSet
-    OLD_SV : SimpleKeyword
-        BasisSet
-    OLD_SV_P : SimpleKeyword
-        BasisSet
-    OLD_SVP : SimpleKeyword
-        BasisSet
-    OLD_TZV : SimpleKeyword
-        BasisSet
-    OLD_TZV_P : SimpleKeyword
-        BasisSet
-    OLD_TZVP : SimpleKeyword
-        BasisSet
-    OLD_TZVPP : SimpleKeyword
-        BasisSet
-    OLD_ZORA_SV_P : SimpleKeyword
-        BasisSet
-    OLD_ZORA_SVP : SimpleKeyword
-        BasisSet
-    OLD_ZORA_TZV_P : SimpleKeyword
-        BasisSet
-    OLD_ZORA_TZVP : SimpleKeyword
-        BasisSet
-    OLD_ZORA_TZVPP : SimpleKeyword
-        BasisSet
-    PARTRIDGE_1 : SimpleKeyword
-        BasisSet
-    PARTRIDGE_2 : SimpleKeyword
-        BasisSet
-    PARTRIDGE_3 : SimpleKeyword
-        BasisSet
-    PARTRIDGE_4 : SimpleKeyword
-        BasisSet
-    PC_0 : SimpleKeyword
-        BasisSet
-    PC_1 : SimpleKeyword
-        BasisSet
-    PC_2 : SimpleKeyword
-        BasisSet
-    PC_3 : SimpleKeyword
-        BasisSet
-    PC_4 : SimpleKeyword
-        BasisSet
-    PCH_1 : SimpleKeyword
-        BasisSet
-    PCH_2 : SimpleKeyword
-        BasisSet
-    PCH_3 : SimpleKeyword
-        BasisSet
-    PCH_4 : SimpleKeyword
-        BasisSet
-    PCJ_0 : SimpleKeyword
-        BasisSet
-    PCJ_1 : SimpleKeyword
-        BasisSet
-    PCJ_2 : SimpleKeyword
-        BasisSet
-    PCJ_3 : SimpleKeyword
-        BasisSet
-    PCJ_4 : SimpleKeyword
-        BasisSet
-    PCSEG_0 : SimpleKeyword
-        BasisSet
-    PCSEG_1 : SimpleKeyword
-        BasisSet
-    PCSEG_2 : SimpleKeyword
-        BasisSet
-    PCSEG_3 : SimpleKeyword
-        BasisSet
-    PCSEG_4 : SimpleKeyword
-        BasisSet
-    PCSSEG_0 : SimpleKeyword
-        BasisSet
-    PCSSEG_1 : SimpleKeyword
-        BasisSet
-    PCSSEG_2 : SimpleKeyword
-        BasisSet
-    PCSSEG_3 : SimpleKeyword
-        BasisSet
-    PCSSEG_4 : SimpleKeyword
-        BasisSet
-    PCX_1 : SimpleKeyword
-        BasisSet
-    PCX_2 : SimpleKeyword
-        BasisSet
-    PCX_3 : SimpleKeyword
-        BasisSet
-    PCX_4 : SimpleKeyword
-        BasisSet
-    QZVP : SimpleKeyword
-        BasisSet
-    QZVPP : SimpleKeyword
-        BasisSet
-    SAPPORO_DKH3_DZP_2012 : SimpleKeyword
-        BasisSet
-    SAPPORO_DKH3_QZP_2012 : SimpleKeyword
-        BasisSet
-    SAPPORO_DKH3_TZP_2012 : SimpleKeyword
-        BasisSet
-    SAPPORO_DZP_2012 : SimpleKeyword
-        BasisSet
-    SAPPORO_QZP_2012 : SimpleKeyword
-        BasisSet
-    SAPPORO_TZP_2012 : SimpleKeyword
-        BasisSet
-    SARC_DKH_SVP : SimpleKeyword
-        BasisSet
-    SARC_DKH_TZVP : SimpleKeyword
-        BasisSet
-    SARC_DKH_TZVPP : SimpleKeyword
-        BasisSet
-    SARC_ZORA_SVP : SimpleKeyword
-        BasisSet
-    SARC_ZORA_TZVP : SimpleKeyword
-        BasisSet
-    SARC_ZORA_TZVPP : SimpleKeyword
-        BasisSet
-    SARC2_DKH_QZV : SimpleKeyword
-        BasisSet
-    SARC2_DKH_QZVP : SimpleKeyword
-        BasisSet
-    SARC2_ZORA_QZV : SimpleKeyword
-        BasisSet
-    SARC2_ZORA_QZVP : SimpleKeyword
-        BasisSet
-    SAUG_ANO_PV5Z : SimpleKeyword
-        BasisSet
-    SAUG_ANO_PVDZ : SimpleKeyword
-        BasisSet
-    SAUG_ANO_PVQZ : SimpleKeyword
-        BasisSet
-    SAUG_ANO_PVTZ : SimpleKeyword
-        BasisSet
-    STO_3G : SimpleKeyword
-        BasisSet
-    SV : SimpleKeyword
-        BasisSet
-    SV_P : SimpleKeyword
-        BasisSet
-    SVP : SimpleKeyword
-        BasisSet
-    TZV : SimpleKeyword
-        BasisSet
-    TZV_P : SimpleKeyword
-        BasisSet
-    TZVP : SimpleKeyword
-        BasisSet
-    TZVPP : SimpleKeyword
-        BasisSet
-    UGBS : SimpleKeyword
-        BasisSet
-    VDZP : SimpleKeyword
-        BasisSet
-    W1_DZ : SimpleKeyword
-        BasisSet
-    W1_MTSMALL : SimpleKeyword
-        BasisSet
-    W1_OPT : SimpleKeyword
-        BasisSet
-    W1_QZ : SimpleKeyword
-        BasisSet
-    W1_TZ : SimpleKeyword
-        BasisSet
-    WACHTERSPLUSF : SimpleKeyword
-        BasisSet
-    X2C_QZVPALL : SimpleKeyword
-        BasisSet
-    X2C_QZVPALL_2C : SimpleKeyword
-        BasisSet
-    X2C_QZVPALL_2C_S : SimpleKeyword
-        BasisSet
-    X2C_QZVPALL_S : SimpleKeyword
-        BasisSet
-    X2C_QZVPPALL : SimpleKeyword
-        BasisSet
-    X2C_QZVPPALL_2C : SimpleKeyword
-        BasisSet
-    X2C_QZVPPALL_2C_S : SimpleKeyword
-        BasisSet
-    X2C_QZVPPALL_S : SimpleKeyword
-        BasisSet
-    X2C_SV_P_ALL : SimpleKeyword
-        BasisSet
-    X2C_SV_P_ALL_2C : SimpleKeyword
-        BasisSet
-    X2C_SV_P_ALL_S : SimpleKeyword
-        BasisSet
-    X2C_SVPALL : SimpleKeyword
-        BasisSet
-    X2C_SVPALL_2C : SimpleKeyword
-        BasisSet
-    X2C_SVPALL_S : SimpleKeyword
-        BasisSet
-    X2C_TZVPALL : SimpleKeyword
-        BasisSet
-    X2C_TZVPALL_2C : SimpleKeyword
-        BasisSet
-    X2C_TZVPALL_S : SimpleKeyword
-        BasisSet
-    X2C_TZVPPALL : SimpleKeyword
-        BasisSet
-    X2C_TZVPPALL_2C : SimpleKeyword
-        BasisSet
-    X2C_TZVPPALL_S : SimpleKeyword
-        BasisSet
-    ZORA_DEF2_QZVPP : SimpleKeyword
-        BasisSet
-    ZORA_DEF2_SV_P : SimpleKeyword
-        BasisSet
-    ZORA_DEF2_SVP : SimpleKeyword
-        BasisSet
-    ZORA_DEF2_TZVP : SimpleKeyword
-        BasisSet
-    ZORA_DEF2_TZVP_F : SimpleKeyword
-        BasisSet
-    ZORA_DEF2_TZVPP : SimpleKeyword
-        BasisSet
-    ZORA_MA_DEF2_QZVPP : SimpleKeyword
-        BasisSet
-    ZORA_MA_DEF2_SV_P : SimpleKeyword
-        BasisSet
-    ZORA_MA_DEF2_SVP : SimpleKeyword
-        BasisSet
-    ZORA_MA_DEF2_TZVP : SimpleKeyword
-        BasisSet
-    ZORA_MA_DEF2_TZVP_F : SimpleKeyword
-        BasisSet
-    ZORA_MA_DEF2_TZVPP : SimpleKeyword
-        BasisSet
-    ZORA_QZVP : SimpleKeyword
-        BasisSet
-    ZORA_QZVPP : SimpleKeyword
-        BasisSet
-    ZORA_SV_P : SimpleKeyword
-        BasisSet
-    ZORA_SVP : SimpleKeyword
-        BasisSet
-    ZORA_TZV_P : SimpleKeyword
-        BasisSet
-    ZORA_TZVP : SimpleKeyword
-        BasisSet
-    ZORA_TZVPP : SimpleKeyword
-        BasisSet
-    """
+    """Enum to store all simple keywords of type BasisSet."""
 
     G3_21G = SimpleKeyword("3-21g")
+    """SimpleKeyword: BasisSet."""
     G3_21GSP = SimpleKeyword("3-21gsp")
+    """SimpleKeyword: BasisSet."""
     G4_22GSP = SimpleKeyword("4-22gsp")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSPLUSG_2D_2P = SimpleKeyword("6-31++g(2d,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSPLUSG_2D_P = SimpleKeyword("6-31++g(2d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSPLUSG_2DF_2P = SimpleKeyword("6-31++g(2df,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSPLUSG_2DF_2PD = SimpleKeyword("6-31++g(2df,2pd)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSPLUSG_D_P = SimpleKeyword("6-31++g(d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSPLUSGSTARSTAR = SimpleKeyword("6-31++g**")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSG_2D_2P = SimpleKeyword("6-31+g(2d,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSG_2D_P = SimpleKeyword("6-31+g(2d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSG_2D = SimpleKeyword("6-31+g(2d)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSG_2DF_2P = SimpleKeyword("6-31+g(2df,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSG_2DF_2PD = SimpleKeyword("6-31+g(2df,2pd)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSG_2DF = SimpleKeyword("6-31+g(2df)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSG_D_P = SimpleKeyword("6-31+g(d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSG_D = SimpleKeyword("6-31+g(d)")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSGSTAR = SimpleKeyword("6-31+g*")
+    """SimpleKeyword: BasisSet."""
     G6_31PLUSGSTARSTAR = SimpleKeyword("6-31+g**")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSPLUSG_2D_2P = SimpleKeyword("6-311++g(2d,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSPLUSG_2D_P = SimpleKeyword("6-311++g(2d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSPLUSG_2DF_2P = SimpleKeyword("6-311++g(2df,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSPLUSG_2DF_2PD = SimpleKeyword("6-311++g(2df,2pd)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSPLUSG_3DF_3PD = SimpleKeyword("6-311++g(3df,3pd)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSPLUSG_D_P = SimpleKeyword("6-311++g(d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSPLUSGSTARSTAR = SimpleKeyword("6-311++g**")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSG_2D_2P = SimpleKeyword("6-311+g(2d,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSG_2D_P = SimpleKeyword("6-311+g(2d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSG_2D = SimpleKeyword("6-311+g(2d)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSG_2DF_2P = SimpleKeyword("6-311+g(2df,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSG_2DF_2PD = SimpleKeyword("6-311+g(2df,2pd)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSG_2DF = SimpleKeyword("6-311+g(2df)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSG_3DF_2P = SimpleKeyword("6-311+g(3df,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSG_3DF_3PD = SimpleKeyword("6-311+g(3df,3pd)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSG_3DF = SimpleKeyword("6-311+g(3df)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSG_D_P = SimpleKeyword("6-311+g(d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSG_D = SimpleKeyword("6-311+g(d)")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSGSTAR = SimpleKeyword("6-311+g*")
+    """SimpleKeyword: BasisSet."""
     G6_311PLUSGSTARSTAR = SimpleKeyword("6-311+g**")
+    """SimpleKeyword: BasisSet."""
     G6_311G = SimpleKeyword("6-311g")
+    """SimpleKeyword: BasisSet."""
     G6_311G_2D_2P = SimpleKeyword("6-311g(2d,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_311G_2D_P = SimpleKeyword("6-311g(2d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_311G_2D = SimpleKeyword("6-311g(2d)")
+    """SimpleKeyword: BasisSet."""
     G6_311G_2DF_2P = SimpleKeyword("6-311g(2df,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_311G_2DF_2PD = SimpleKeyword("6-311g(2df,2pd)")
+    """SimpleKeyword: BasisSet."""
     G6_311G_2DF = SimpleKeyword("6-311g(2df)")
+    """SimpleKeyword: BasisSet."""
     G6_311G_3DF_3PD = SimpleKeyword("6-311g(3df,3pd)")
+    """SimpleKeyword: BasisSet."""
     G6_311G_3DF = SimpleKeyword("6-311g(3df)")
+    """SimpleKeyword: BasisSet."""
     G6_311G_D_P = SimpleKeyword("6-311g(d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_311G_D = SimpleKeyword("6-311g(d)")
+    """SimpleKeyword: BasisSet."""
     G6_311GSTAR = SimpleKeyword("6-311g*")
+    """SimpleKeyword: BasisSet."""
     G6_311GSTARSTAR = SimpleKeyword("6-311g**")
+    """SimpleKeyword: BasisSet."""
     G6_31G = SimpleKeyword("6-31g")
+    """SimpleKeyword: BasisSet."""
     G6_31G_2D_2P = SimpleKeyword("6-31g(2d,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_31G_2D_P = SimpleKeyword("6-31g(2d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_31G_2D = SimpleKeyword("6-31g(2d)")
+    """SimpleKeyword: BasisSet."""
     G6_31G_2DF_2P = SimpleKeyword("6-31g(2df,2p)")
+    """SimpleKeyword: BasisSet."""
     G6_31G_2DF_2PD = SimpleKeyword("6-31g(2df,2pd)")
+    """SimpleKeyword: BasisSet."""
     G6_31G_2DF = SimpleKeyword("6-31g(2df)")
+    """SimpleKeyword: BasisSet."""
     G6_31G_D_P = SimpleKeyword("6-31g(d,p)")
+    """SimpleKeyword: BasisSet."""
     G6_31G_D = SimpleKeyword("6-31g(d)")
+    """SimpleKeyword: BasisSet."""
     G6_31GSTAR = SimpleKeyword("6-31g*")
+    """SimpleKeyword: BasisSet."""
     G6_31GSTARSTAR = SimpleKeyword("6-31g**")
+    """SimpleKeyword: BasisSet."""
     AHGBS_5 = SimpleKeyword("ahgbs-5")
+    """SimpleKeyword: BasisSet."""
     AHGBS_7 = SimpleKeyword("ahgbs-7")
+    """SimpleKeyword: BasisSet."""
     AHGBS_9 = SimpleKeyword("ahgbs-9")
+    """SimpleKeyword: BasisSet."""
     AHGBSP1_5 = SimpleKeyword("ahgbsp1-5")
+    """SimpleKeyword: BasisSet."""
     AHGBSP1_7 = SimpleKeyword("ahgbsp1-7")
+    """SimpleKeyword: BasisSet."""
     AHGBSP1_9 = SimpleKeyword("ahgbsp1-9")
+    """SimpleKeyword: BasisSet."""
     AHGBSP2_5 = SimpleKeyword("ahgbsp2-5")
+    """SimpleKeyword: BasisSet."""
     AHGBSP2_7 = SimpleKeyword("ahgbsp2-7")
+    """SimpleKeyword: BasisSet."""
     AHGBSP2_9 = SimpleKeyword("ahgbsp2-9")
+    """SimpleKeyword: BasisSet."""
     AHGBSP3_5 = SimpleKeyword("ahgbsp3-5")
+    """SimpleKeyword: BasisSet."""
     AHGBSP3_7 = SimpleKeyword("ahgbsp3-7")
+    """SimpleKeyword: BasisSet."""
     AHGBSP3_9 = SimpleKeyword("ahgbsp3-9")
+    """SimpleKeyword: BasisSet."""
     ANO_PC_0 = SimpleKeyword("ano-pc-0")
+    """SimpleKeyword: BasisSet."""
     ANO_PC_0_POL = SimpleKeyword("ano-pc-0-pol")
+    """SimpleKeyword: BasisSet."""
     ANO_PV5Z = SimpleKeyword("ano-pv5z")
+    """SimpleKeyword: BasisSet."""
     ANO_PV6Z = SimpleKeyword("ano-pv6z")
+    """SimpleKeyword: BasisSet."""
     ANO_PVDZ = SimpleKeyword("ano-pvdz")
+    """SimpleKeyword: BasisSet."""
     ANO_PVQZ = SimpleKeyword("ano-pvqz")
+    """SimpleKeyword: BasisSet."""
     ANO_PVTZ = SimpleKeyword("ano-pvtz")
+    """SimpleKeyword: BasisSet."""
     ANO_RCC_DZP = SimpleKeyword("ano-rcc-dzp")
+    """SimpleKeyword: BasisSet."""
     ANO_RCC_FULL = SimpleKeyword("ano-rcc-full")
+    """SimpleKeyword: BasisSet."""
     ANO_RCC_MB = SimpleKeyword("ano-rcc-mb")
+    """SimpleKeyword: BasisSet."""
     ANO_RCC_QZP = SimpleKeyword("ano-rcc-qzp")
+    """SimpleKeyword: BasisSet."""
     ANO_RCC_TZP = SimpleKeyword("ano-rcc-tzp")
+    """SimpleKeyword: BasisSet."""
     ANO_SZ = SimpleKeyword("ano-sz")
+    """SimpleKeyword: BasisSet."""
     ANO_SZ_DKH_SMALL = SimpleKeyword("ano-sz-dkh-small")
+    """SimpleKeyword: BasisSet."""
     APR_CC_PV_QPLUSD_Z = SimpleKeyword("apr-cc-pv(q+d)z")
+    """SimpleKeyword: BasisSet."""
     AUG_ANO_PV5Z = SimpleKeyword("aug-ano-pv5z")
+    """SimpleKeyword: BasisSet."""
     AUG_ANO_PVDZ = SimpleKeyword("aug-ano-pvdz")
+    """SimpleKeyword: BasisSet."""
     AUG_ANO_PVQZ = SimpleKeyword("aug-ano-pvqz")
+    """SimpleKeyword: BasisSet."""
     AUG_ANO_PVTZ = SimpleKeyword("aug-ano-pvtz")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PCV5Z = SimpleKeyword("aug-cc-pcv5z")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PCV5Z_PP = SimpleKeyword("aug-cc-pcv5z-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PCV6Z = SimpleKeyword("aug-cc-pcv6z")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PCVDZ = SimpleKeyword("aug-cc-pcvdz")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PCVDZ_PP = SimpleKeyword("aug-cc-pcvdz-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PCVQZ = SimpleKeyword("aug-cc-pcvqz")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PCVQZ_PP = SimpleKeyword("aug-cc-pcvqz-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PCVTZ = SimpleKeyword("aug-cc-pcvtz")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PCVTZ_PP = SimpleKeyword("aug-cc-pcvtz-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PV5_PLUSD_Z = SimpleKeyword("aug-cc-pv5(+d)z")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PV5Z = SimpleKeyword("aug-cc-pv5z")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PV5Z_DK = SimpleKeyword("aug-cc-pv5z-dk")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PV5Z_PP = SimpleKeyword("aug-cc-pv5z-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PV5Z_PP_OPTRI = SimpleKeyword("aug-cc-pv5z-pp-optri")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PV6_PLUSD_Z = SimpleKeyword("aug-cc-pv6(+d)z")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PV6Z = SimpleKeyword("aug-cc-pv6z")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PV7Z = SimpleKeyword("aug-cc-pv7z")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVD_PLUSD_Z = SimpleKeyword("aug-cc-pvd(+d)z")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVDZ = SimpleKeyword("aug-cc-pvdz")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVDZ_DK = SimpleKeyword("aug-cc-pvdz-dk")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVDZ_PP = SimpleKeyword("aug-cc-pvdz-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVDZ_PP_OPTRI = SimpleKeyword("aug-cc-pvdz-pp-optri")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVQ_PLUSD_Z = SimpleKeyword("aug-cc-pvq(+d)z")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVQZ = SimpleKeyword("aug-cc-pvqz")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVQZ_DK = SimpleKeyword("aug-cc-pvqz-dk")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVQZ_PP = SimpleKeyword("aug-cc-pvqz-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVQZ_PP_OPTRI = SimpleKeyword("aug-cc-pvqz-pp-optri")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVT_PLUSD_Z = SimpleKeyword("aug-cc-pvt(+d)z")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVTZ = SimpleKeyword("aug-cc-pvtz")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVTZ_DK = SimpleKeyword("aug-cc-pvtz-dk")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVTZ_J = SimpleKeyword("aug-cc-pvtz-j")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVTZ_PP = SimpleKeyword("aug-cc-pvtz-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PVTZ_PP_OPTRI = SimpleKeyword("aug-cc-pvtz-pp-optri")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCV5Z = SimpleKeyword("aug-cc-pwcv5z")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCV5Z_DK = SimpleKeyword("aug-cc-pwcv5z-dk")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCV5Z_PP = SimpleKeyword("aug-cc-pwcv5z-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCV5Z_PP_OPTRI = SimpleKeyword("aug-cc-pwcv5z-pp-optri")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVDZ = SimpleKeyword("aug-cc-pwcvdz")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVDZ_DK = SimpleKeyword("aug-cc-pwcvdz-dk")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVDZ_PP = SimpleKeyword("aug-cc-pwcvdz-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVDZ_PP_OPTRI = SimpleKeyword("aug-cc-pwcvdz-pp-optri")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVQZ = SimpleKeyword("aug-cc-pwcvqz")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVQZ_DK = SimpleKeyword("aug-cc-pwcvqz-dk")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVQZ_PP = SimpleKeyword("aug-cc-pwcvqz-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVQZ_PP_OPTRI = SimpleKeyword("aug-cc-pwcvqz-pp-optri")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVTZ = SimpleKeyword("aug-cc-pwcvtz")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVTZ_DK = SimpleKeyword("aug-cc-pwcvtz-dk")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVTZ_PP = SimpleKeyword("aug-cc-pwcvtz-pp")
+    """SimpleKeyword: BasisSet."""
     AUG_CC_PWCVTZ_PP_OPTRI = SimpleKeyword("aug-cc-pwcvtz-pp-optri")
+    """SimpleKeyword: BasisSet."""
     AUG_PC_0 = SimpleKeyword("aug-pc-0")
+    """SimpleKeyword: BasisSet."""
     AUG_PC_1 = SimpleKeyword("aug-pc-1")
+    """SimpleKeyword: BasisSet."""
     AUG_PC_2 = SimpleKeyword("aug-pc-2")
+    """SimpleKeyword: BasisSet."""
     AUG_PC_3 = SimpleKeyword("aug-pc-3")
+    """SimpleKeyword: BasisSet."""
     AUG_PC_4 = SimpleKeyword("aug-pc-4")
+    """SimpleKeyword: BasisSet."""
     AUG_PCH_1 = SimpleKeyword("aug-pch-1")
+    """SimpleKeyword: BasisSet."""
     AUG_PCH_2 = SimpleKeyword("aug-pch-2")
+    """SimpleKeyword: BasisSet."""
     AUG_PCH_3 = SimpleKeyword("aug-pch-3")
+    """SimpleKeyword: BasisSet."""
     AUG_PCH_4 = SimpleKeyword("aug-pch-4")
+    """SimpleKeyword: BasisSet."""
     AUG_PCJ_0 = SimpleKeyword("aug-pcj-0")
+    """SimpleKeyword: BasisSet."""
     AUG_PCJ_1 = SimpleKeyword("aug-pcj-1")
+    """SimpleKeyword: BasisSet."""
     AUG_PCJ_2 = SimpleKeyword("aug-pcj-2")
+    """SimpleKeyword: BasisSet."""
     AUG_PCJ_3 = SimpleKeyword("aug-pcj-3")
+    """SimpleKeyword: BasisSet."""
     AUG_PCJ_4 = SimpleKeyword("aug-pcj-4")
+    """SimpleKeyword: BasisSet."""
     AUG_PCSEG_0 = SimpleKeyword("aug-pcseg-0")
+    """SimpleKeyword: BasisSet."""
     AUG_PCSEG_1 = SimpleKeyword("aug-pcseg-1")
+    """SimpleKeyword: BasisSet."""
     AUG_PCSEG_2 = SimpleKeyword("aug-pcseg-2")
+    """SimpleKeyword: BasisSet."""
     AUG_PCSEG_3 = SimpleKeyword("aug-pcseg-3")
+    """SimpleKeyword: BasisSet."""
     AUG_PCSEG_4 = SimpleKeyword("aug-pcseg-4")
+    """SimpleKeyword: BasisSet."""
     AUG_PCSSEG_0 = SimpleKeyword("aug-pcsseg-0")
+    """SimpleKeyword: BasisSet."""
     AUG_PCSSEG_1 = SimpleKeyword("aug-pcsseg-1")
+    """SimpleKeyword: BasisSet."""
     AUG_PCSSEG_2 = SimpleKeyword("aug-pcsseg-2")
+    """SimpleKeyword: BasisSet."""
     AUG_PCSSEG_3 = SimpleKeyword("aug-pcsseg-3")
+    """SimpleKeyword: BasisSet."""
     AUG_PCSSEG_4 = SimpleKeyword("aug-pcsseg-4")
+    """SimpleKeyword: BasisSet."""
     AUG_PCX_1 = SimpleKeyword("aug-pcx-1")
+    """SimpleKeyword: BasisSet."""
     AUG_PCX_2 = SimpleKeyword("aug-pcx-2")
+    """SimpleKeyword: BasisSet."""
     AUG_PCX_3 = SimpleKeyword("aug-pcx-3")
+    """SimpleKeyword: BasisSet."""
     AUG_PCX_4 = SimpleKeyword("aug-pcx-4")
+    """SimpleKeyword: BasisSet."""
     CC_PCV5Z = SimpleKeyword("cc-pcv5z")
+    """SimpleKeyword: BasisSet."""
     CC_PCV5Z_PP = SimpleKeyword("cc-pcv5z-pp")
+    """SimpleKeyword: BasisSet."""
     CC_PCV6Z = SimpleKeyword("cc-pcv6z")
+    """SimpleKeyword: BasisSet."""
     CC_PCVDZ = SimpleKeyword("cc-pcvdz")
+    """SimpleKeyword: BasisSet."""
     CC_PCVDZ_F12 = SimpleKeyword("cc-pcvdz-f12")
+    """SimpleKeyword: BasisSet."""
     CC_PCVDZ_F12_OPTRI = SimpleKeyword("cc-pcvdz-f12-optri")
+    """SimpleKeyword: BasisSet."""
     CC_PCVDZ_PP = SimpleKeyword("cc-pcvdz-pp")
+    """SimpleKeyword: BasisSet."""
     CC_PCVQZ = SimpleKeyword("cc-pcvqz")
+    """SimpleKeyword: BasisSet."""
     CC_PCVQZ_F12 = SimpleKeyword("cc-pcvqz-f12")
+    """SimpleKeyword: BasisSet."""
     CC_PCVQZ_F12_OPTRI = SimpleKeyword("cc-pcvqz-f12-optri")
+    """SimpleKeyword: BasisSet."""
     CC_PCVQZ_PP = SimpleKeyword("cc-pcvqz-pp")
+    """SimpleKeyword: BasisSet."""
     CC_PCVTZ = SimpleKeyword("cc-pcvtz")
+    """SimpleKeyword: BasisSet."""
     CC_PCVTZ_F12 = SimpleKeyword("cc-pcvtz-f12")
+    """SimpleKeyword: BasisSet."""
     CC_PCVTZ_F12_OPTRI = SimpleKeyword("cc-pcvtz-f12-optri")
+    """SimpleKeyword: BasisSet."""
     CC_PCVTZ_PP = SimpleKeyword("cc-pcvtz-pp")
+    """SimpleKeyword: BasisSet."""
     CC_PV5_PLUSD_Z = SimpleKeyword("cc-pv5(+d)z")
+    """SimpleKeyword: BasisSet."""
     CC_PV5Z = SimpleKeyword("cc-pv5z")
+    """SimpleKeyword: BasisSet."""
     CC_PV5Z_DK = SimpleKeyword("cc-pv5z-dk")
+    """SimpleKeyword: BasisSet."""
     CC_PV5Z_PP = SimpleKeyword("cc-pv5z-pp")
+    """SimpleKeyword: BasisSet."""
     CC_PV6Z = SimpleKeyword("cc-pv6z")
+    """SimpleKeyword: BasisSet."""
     CC_PV7Z = SimpleKeyword("cc-pv7z")
+    """SimpleKeyword: BasisSet."""
     CC_PV8Z = SimpleKeyword("cc-pv8z")
+    """SimpleKeyword: BasisSet."""
     CC_PVD_PLUSD_Z = SimpleKeyword("cc-pvd(+d)z")
+    """SimpleKeyword: BasisSet."""
     CC_PVDZ = SimpleKeyword("cc-pvdz")
+    """SimpleKeyword: BasisSet."""
     CC_PVDZ_DK = SimpleKeyword("cc-pvdz-dk")
+    """SimpleKeyword: BasisSet."""
     CC_PVDZ_DK3 = SimpleKeyword("cc-pvdz-dk3")
+    """SimpleKeyword: BasisSet."""
     CC_PVDZ_F12 = SimpleKeyword("cc-pvdz-f12")
+    """SimpleKeyword: BasisSet."""
     CC_PVDZ_F12_CABS = SimpleKeyword("cc-pvdz-f12-cabs")
+    """SimpleKeyword: BasisSet."""
     CC_PVDZ_F12_OPTRI = SimpleKeyword("cc-pvdz-f12-optri")
+    """SimpleKeyword: BasisSet."""
     CC_PVDZ_PP = SimpleKeyword("cc-pvdz-pp")
+    """SimpleKeyword: BasisSet."""
     CC_PVDZ_PP_F12 = SimpleKeyword("cc-pvdz-pp-f12")
+    """SimpleKeyword: BasisSet."""
     CC_PVDZ_PP_F12_OPTRI = SimpleKeyword("cc-pvdz-pp-f12-optri")
+    """SimpleKeyword: BasisSet."""
     CC_PVQ_PLUSD_Z = SimpleKeyword("cc-pvq(+d)z")
+    """SimpleKeyword: BasisSet."""
     CC_PVQZ = SimpleKeyword("cc-pvqz")
+    """SimpleKeyword: BasisSet."""
     CC_PVQZ_DK = SimpleKeyword("cc-pvqz-dk")
+    """SimpleKeyword: BasisSet."""
     CC_PVQZ_DK3 = SimpleKeyword("cc-pvqz-dk3")
+    """SimpleKeyword: BasisSet."""
     CC_PVQZ_F12 = SimpleKeyword("cc-pvqz-f12")
+    """SimpleKeyword: BasisSet."""
     CC_PVQZ_F12_CABS = SimpleKeyword("cc-pvqz-f12-cabs")
+    """SimpleKeyword: BasisSet."""
     CC_PVQZ_F12_OPTRI = SimpleKeyword("cc-pvqz-f12-optri")
+    """SimpleKeyword: BasisSet."""
     CC_PVQZ_PP = SimpleKeyword("cc-pvqz-pp")
+    """SimpleKeyword: BasisSet."""
     CC_PVQZ_PP_F12 = SimpleKeyword("cc-pvqz-pp-f12")
+    """SimpleKeyword: BasisSet."""
     CC_PVQZ_PP_F12_OPTRI = SimpleKeyword("cc-pvqz-pp-f12-optri")
+    """SimpleKeyword: BasisSet."""
     CC_PVT_PLUSD_Z = SimpleKeyword("cc-pvt(+d)z")
+    """SimpleKeyword: BasisSet."""
     CC_PVTZ = SimpleKeyword("cc-pvtz")
+    """SimpleKeyword: BasisSet."""
     CC_PVTZ_DK = SimpleKeyword("cc-pvtz-dk")
+    """SimpleKeyword: BasisSet."""
     CC_PVTZ_DK3 = SimpleKeyword("cc-pvtz-dk3")
+    """SimpleKeyword: BasisSet."""
     CC_PVTZ_F12 = SimpleKeyword("cc-pvtz-f12")
+    """SimpleKeyword: BasisSet."""
     CC_PVTZ_F12_CABS = SimpleKeyword("cc-pvtz-f12-cabs")
+    """SimpleKeyword: BasisSet."""
     CC_PVTZ_F12_OPTRI = SimpleKeyword("cc-pvtz-f12-optri")
+    """SimpleKeyword: BasisSet."""
     CC_PVTZ_PP = SimpleKeyword("cc-pvtz-pp")
+    """SimpleKeyword: BasisSet."""
     CC_PVTZ_PP_F12 = SimpleKeyword("cc-pvtz-pp-f12")
+    """SimpleKeyword: BasisSet."""
     CC_PVTZ_PP_F12_OPTRI = SimpleKeyword("cc-pvtz-pp-f12-optri")
+    """SimpleKeyword: BasisSet."""
     CC_PWCV5Z = SimpleKeyword("cc-pwcv5z")
+    """SimpleKeyword: BasisSet."""
     CC_PWCV5Z_DK = SimpleKeyword("cc-pwcv5z-dk")
+    """SimpleKeyword: BasisSet."""
     CC_PWCV5Z_PP = SimpleKeyword("cc-pwcv5z-pp")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVDZ = SimpleKeyword("cc-pwcvdz")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVDZ_DK = SimpleKeyword("cc-pwcvdz-dk")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVDZ_DK3 = SimpleKeyword("cc-pwcvdz-dk3")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVDZ_PP = SimpleKeyword("cc-pwcvdz-pp")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVQZ = SimpleKeyword("cc-pwcvqz")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVQZ_DK = SimpleKeyword("cc-pwcvqz-dk")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVQZ_DK3 = SimpleKeyword("cc-pwcvqz-dk3")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVQZ_PP = SimpleKeyword("cc-pwcvqz-pp")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVTZ = SimpleKeyword("cc-pwcvtz")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVTZ_DK = SimpleKeyword("cc-pwcvtz-dk")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVTZ_DK3 = SimpleKeyword("cc-pwcvtz-dk3")
+    """SimpleKeyword: BasisSet."""
     CC_PWCVTZ_PP = SimpleKeyword("cc-pwcvtz-pp")
+    """SimpleKeyword: BasisSet."""
     CP = SimpleKeyword("cp")
+    """SimpleKeyword: BasisSet."""
     CP_PPP = SimpleKeyword("cp(ppp)")
+    """SimpleKeyword: BasisSet."""
     CRENBL = SimpleKeyword("crenbl")
+    """SimpleKeyword: BasisSet."""
     D95 = SimpleKeyword("d95")
+    """SimpleKeyword: BasisSet."""
     D95P = SimpleKeyword("d95p")
+    """SimpleKeyword: BasisSet."""
     DEF_SV_P = SimpleKeyword("def-sv(p)")
+    """SimpleKeyword: BasisSet."""
     DEF_SVP = SimpleKeyword("def-svp")
+    """SimpleKeyword: BasisSet."""
     DEF_TZVP = SimpleKeyword("def-tzvp")
+    """SimpleKeyword: BasisSet."""
     DEF_TZVPP = SimpleKeyword("def-tzvpp")
+    """SimpleKeyword: BasisSet."""
     DEF2_MSVP = SimpleKeyword("def2-msvp")
+    """SimpleKeyword: BasisSet."""
     DEF2_MTZVP = SimpleKeyword("def2-mtzvp")
+    """SimpleKeyword: BasisSet."""
     DEF2_MTZVPP = SimpleKeyword("def2-mtzvpp")
+    """SimpleKeyword: BasisSet."""
     DEF2_QZVP = SimpleKeyword("def2-qzvp")
+    """SimpleKeyword: BasisSet."""
     DEF2_QZVPD = SimpleKeyword("def2-qzvpd")
+    """SimpleKeyword: BasisSet."""
     DEF2_QZVPP = SimpleKeyword("def2-qzvpp")
+    """SimpleKeyword: BasisSet."""
     DEF2_QZVPPD = SimpleKeyword("def2-qzvppd")
+    """SimpleKeyword: BasisSet."""
     DEF2_SV_P = SimpleKeyword("def2-sv(p)")
+    """SimpleKeyword: BasisSet."""
     DEF2_SVP = SimpleKeyword("def2-svp")
+    """SimpleKeyword: BasisSet."""
     DEF2_SVPD = SimpleKeyword("def2-svpd")
+    """SimpleKeyword: BasisSet."""
     DEF2_TZVP = SimpleKeyword("def2-tzvp")
+    """SimpleKeyword: BasisSet."""
     DEF2_TZVP_F = SimpleKeyword("def2-tzvp(-f)")
+    """SimpleKeyword: BasisSet."""
     DEF2_TZVPD = SimpleKeyword("def2-tzvpd")
+    """SimpleKeyword: BasisSet."""
     DEF2_TZVPP = SimpleKeyword("def2-tzvpp")
+    """SimpleKeyword: BasisSet."""
     DEF2_TZVPPD = SimpleKeyword("def2-tzvppd")
+    """SimpleKeyword: BasisSet."""
     DHF_QZVP = SimpleKeyword("dhf-qzvp")
+    """SimpleKeyword: BasisSet."""
     DHF_QZVP_2C = SimpleKeyword("dhf-qzvp-2c")
+    """SimpleKeyword: BasisSet."""
     DHF_QZVPP = SimpleKeyword("dhf-qzvpp")
+    """SimpleKeyword: BasisSet."""
     DHF_QZVPP_2C = SimpleKeyword("dhf-qzvpp-2c")
+    """SimpleKeyword: BasisSet."""
     DHF_SV_P = SimpleKeyword("dhf-sv(p)")
+    """SimpleKeyword: BasisSet."""
     DHF_SV_P_2C = SimpleKeyword("dhf-sv(p)-2c")
+    """SimpleKeyword: BasisSet."""
     DHF_SVP = SimpleKeyword("dhf-svp")
+    """SimpleKeyword: BasisSet."""
     DHF_SVP_2C = SimpleKeyword("dhf-svp-2c")
+    """SimpleKeyword: BasisSet."""
     DHF_TZVP = SimpleKeyword("dhf-tzvp")
+    """SimpleKeyword: BasisSet."""
     DHF_TZVP_2C = SimpleKeyword("dhf-tzvp-2c")
+    """SimpleKeyword: BasisSet."""
     DHF_TZVPP = SimpleKeyword("dhf-tzvpp")
+    """SimpleKeyword: BasisSet."""
     DHF_TZVPP_2C = SimpleKeyword("dhf-tzvpp-2c")
+    """SimpleKeyword: BasisSet."""
     DKH_DEF2_QZVPP = SimpleKeyword("dkh-def2-qzvpp")
+    """SimpleKeyword: BasisSet."""
     DKH_DEF2_SV_P = SimpleKeyword("dkh-def2-sv(p)")
+    """SimpleKeyword: BasisSet."""
     DKH_DEF2_SVP = SimpleKeyword("dkh-def2-svp")
+    """SimpleKeyword: BasisSet."""
     DKH_DEF2_TZVP = SimpleKeyword("dkh-def2-tzvp")
+    """SimpleKeyword: BasisSet."""
     DKH_DEF2_TZVP_F = SimpleKeyword("dkh-def2-tzvp(-f)")
+    """SimpleKeyword: BasisSet."""
     DKH_DEF2_TZVPP = SimpleKeyword("dkh-def2-tzvpp")
+    """SimpleKeyword: BasisSet."""
     DKH_MA_DEF2_QZVPP = SimpleKeyword("dkh-ma-def2-qzvpp")
+    """SimpleKeyword: BasisSet."""
     DKH_MA_DEF2_SV_P = SimpleKeyword("dkh-ma-def2-sv(p)")
+    """SimpleKeyword: BasisSet."""
     DKH_MA_DEF2_SVP = SimpleKeyword("dkh-ma-def2-svp")
+    """SimpleKeyword: BasisSet."""
     DKH_MA_DEF2_TZVP = SimpleKeyword("dkh-ma-def2-tzvp")
+    """SimpleKeyword: BasisSet."""
     DKH_MA_DEF2_TZVP_F = SimpleKeyword("dkh-ma-def2-tzvp(-f)")
+    """SimpleKeyword: BasisSet."""
     DKH_MA_DEF2_TZVPP = SimpleKeyword("dkh-ma-def2-tzvpp")
+    """SimpleKeyword: BasisSet."""
     DKH_QZVP = SimpleKeyword("dkh-qzvp")
+    """SimpleKeyword: BasisSet."""
     DKH_QZVPP = SimpleKeyword("dkh-qzvpp")
+    """SimpleKeyword: BasisSet."""
     DKH_SV_P = SimpleKeyword("dkh-sv(p)")
+    """SimpleKeyword: BasisSet."""
     DKH_SVP = SimpleKeyword("dkh-svp")
+    """SimpleKeyword: BasisSet."""
     DKH_TZV_P = SimpleKeyword("dkh-tzv(p)")
+    """SimpleKeyword: BasisSet."""
     DKH_TZVP = SimpleKeyword("dkh-tzvp")
+    """SimpleKeyword: BasisSet."""
     DKH_TZVPP = SimpleKeyword("dkh-tzvpp")
+    """SimpleKeyword: BasisSet."""
     EPR_II = SimpleKeyword("epr-ii")
+    """SimpleKeyword: BasisSet."""
     EPR_III = SimpleKeyword("epr-iii")
+    """SimpleKeyword: BasisSet."""
     GFN1BASIS = SimpleKeyword("gfn1Basis")
+    """SimpleKeyword: BasisSet."""
     GFN2BASIS = SimpleKeyword("gfn2Basis")
+    """SimpleKeyword: BasisSet."""
     HAV_5PLUSD_Z = SimpleKeyword("hav(5+d)z")
+    """SimpleKeyword: BasisSet."""
     HAV_QPLUSD_Z = SimpleKeyword("hav(q+d)z")
+    """SimpleKeyword: BasisSet."""
     HAV_TPLUSD_Z = SimpleKeyword("hav(t+d)z")
+    """SimpleKeyword: BasisSet."""
     HAV5Z_PLUSD = SimpleKeyword("hav5z(+d)")
+    """SimpleKeyword: BasisSet."""
     HAVQZ_PLUSD = SimpleKeyword("havqz(+d)")
+    """SimpleKeyword: BasisSet."""
     HAVTZ_PLUSD = SimpleKeyword("havtz(+d)")
+    """SimpleKeyword: BasisSet."""
     HGBS_5 = SimpleKeyword("hgbs-5")
+    """SimpleKeyword: BasisSet."""
     HGBS_7 = SimpleKeyword("hgbs-7")
+    """SimpleKeyword: BasisSet."""
     HGBS_9 = SimpleKeyword("hgbs-9")
+    """SimpleKeyword: BasisSet."""
     HGBSP1_5 = SimpleKeyword("hgbsp1-5")
+    """SimpleKeyword: BasisSet."""
     HGBSP1_7 = SimpleKeyword("hgbsp1-7")
+    """SimpleKeyword: BasisSet."""
     HGBSP1_9 = SimpleKeyword("hgbsp1-9")
+    """SimpleKeyword: BasisSet."""
     HGBSP2_5 = SimpleKeyword("hgbsp2-5")
+    """SimpleKeyword: BasisSet."""
     HGBSP2_7 = SimpleKeyword("hgbsp2-7")
+    """SimpleKeyword: BasisSet."""
     HGBSP2_9 = SimpleKeyword("hgbsp2-9")
+    """SimpleKeyword: BasisSet."""
     HGBSP3_5 = SimpleKeyword("hgbsp3-5")
+    """SimpleKeyword: BasisSet."""
     HGBSP3_7 = SimpleKeyword("hgbsp3-7")
+    """SimpleKeyword: BasisSet."""
     HGBSP3_9 = SimpleKeyword("hgbsp3-9")
+    """SimpleKeyword: BasisSet."""
     IGLO_II = SimpleKeyword("iglo-ii")
+    """SimpleKeyword: BasisSet."""
     IGLO_III = SimpleKeyword("iglo-iii")
+    """SimpleKeyword: BasisSet."""
     JUL_CC_PV_DPLUSD_Z = SimpleKeyword("jul-cc-pv(d+d)z")
+    """SimpleKeyword: BasisSet."""
     JUL_CC_PV_QPLUSD_Z = SimpleKeyword("jul-cc-pv(q+d)z")
+    """SimpleKeyword: BasisSet."""
     JUL_CC_PV_TPLUSD_Z = SimpleKeyword("jul-cc-pv(t+d)z")
+    """SimpleKeyword: BasisSet."""
     JUN_CC_PV_DPLUSD_Z = SimpleKeyword("jun-cc-pv(d+d)z")
+    """SimpleKeyword: BasisSet."""
     JUN_CC_PV_QPLUSD_Z = SimpleKeyword("jun-cc-pv(q+d)z")
+    """SimpleKeyword: BasisSet."""
     JUN_CC_PV_TPLUSD_Z = SimpleKeyword("jun-cc-pv(t+d)z")
+    """SimpleKeyword: BasisSet."""
     LANL08 = SimpleKeyword("lanl08")
+    """SimpleKeyword: BasisSet."""
     LANL08_F = SimpleKeyword("lanl08(f)")
+    """SimpleKeyword: BasisSet."""
     LANL2DZ = SimpleKeyword("lanl2dz")
+    """SimpleKeyword: BasisSet."""
     LANL2TZ = SimpleKeyword("lanl2tz")
+    """SimpleKeyword: BasisSet."""
     LANL2TZ_F = SimpleKeyword("lanl2tz(f)")
+    """SimpleKeyword: BasisSet."""
     M6_31G = SimpleKeyword("m6-31g")
+    """SimpleKeyword: BasisSet."""
     M6_31GSTAR = SimpleKeyword("m6-31g*")
+    """SimpleKeyword: BasisSet."""
     MA_DEF_TZVP = SimpleKeyword("ma-def-tzvp")
+    """SimpleKeyword: BasisSet."""
     MA_DEF2_MSVP = SimpleKeyword("ma-def2-msvp")
+    """SimpleKeyword: BasisSet."""
     MA_DEF2_QZVP = SimpleKeyword("ma-def2-qzvp")
+    """SimpleKeyword: BasisSet."""
     MA_DEF2_QZVPP = SimpleKeyword("ma-def2-qzvpp")
+    """SimpleKeyword: BasisSet."""
     MA_DEF2_SV_P = SimpleKeyword("ma-def2-sv(p)")
+    """SimpleKeyword: BasisSet."""
     MA_DEF2_SVP = SimpleKeyword("ma-def2-svp")
+    """SimpleKeyword: BasisSet."""
     MA_DEF2_TZVP = SimpleKeyword("ma-def2-tzvp")
+    """SimpleKeyword: BasisSet."""
     MA_DEF2_TZVP_F = SimpleKeyword("ma-def2-tzvp(-f)")
+    """SimpleKeyword: BasisSet."""
     MA_DEF2_TZVPP = SimpleKeyword("ma-def2-tzvpp")
+    """SimpleKeyword: BasisSet."""
     MA_DKH_DEF2_QZVPP = SimpleKeyword("ma-dkh-def2-qzvpp")
+    """SimpleKeyword: BasisSet."""
     MA_DKH_DEF2_SV_P = SimpleKeyword("ma-dkh-def2-sv(p)")
+    """SimpleKeyword: BasisSet."""
     MA_DKH_DEF2_SVP = SimpleKeyword("ma-dkh-def2-svp")
+    """SimpleKeyword: BasisSet."""
     MA_DKH_DEF2_TZVP = SimpleKeyword("ma-dkh-def2-tzvp")
+    """SimpleKeyword: BasisSet."""
     MA_DKH_DEF2_TZVP_F = SimpleKeyword("ma-dkh-def2-tzvp(-f)")
+    """SimpleKeyword: BasisSet."""
     MA_DKH_DEF2_TZVPP = SimpleKeyword("ma-dkh-def2-tzvpp")
+    """SimpleKeyword: BasisSet."""
     MA_ZORA_DEF2_QZVPP = SimpleKeyword("ma-zora-def2-qzvpp")
+    """SimpleKeyword: BasisSet."""
     MA_ZORA_DEF2_SV_P = SimpleKeyword("ma-zora-def2-sv(p)")
+    """SimpleKeyword: BasisSet."""
     MA_ZORA_DEF2_SVP = SimpleKeyword("ma-zora-def2-svp")
+    """SimpleKeyword: BasisSet."""
     MA_ZORA_DEF2_TZVP = SimpleKeyword("ma-zora-def2-tzvp")
+    """SimpleKeyword: BasisSet."""
     MA_ZORA_DEF2_TZVP_F = SimpleKeyword("ma-zora-def2-tzvp(-f)")
+    """SimpleKeyword: BasisSet."""
     MA_ZORA_DEF2_TZVPP = SimpleKeyword("ma-zora-def2-tzvpp")
+    """SimpleKeyword: BasisSet."""
     MAUG_CC_PV_DPLUSD_Z = SimpleKeyword("maug-cc-pv(d+d)z")
+    """SimpleKeyword: BasisSet."""
     MAUG_CC_PV_QPLUSD_Z = SimpleKeyword("maug-cc-pv(q+d)z")
+    """SimpleKeyword: BasisSet."""
     MAUG_CC_PV_TPLUSD_Z = SimpleKeyword("maug-cc-pv(t+d)z")
+    """SimpleKeyword: BasisSet."""
     MAY_CC_PV_QPLUSD_Z = SimpleKeyword("may-cc-pv(q+d)z")
+    """SimpleKeyword: BasisSet."""
     MAY_CC_PV_TPLUSD_Z = SimpleKeyword("may-cc-pv(t+d)z")
+    """SimpleKeyword: BasisSet."""
     MIDI = SimpleKeyword("midi")
+    """SimpleKeyword: BasisSet."""
     MINAO = SimpleKeyword("minao")
+    """SimpleKeyword: BasisSet."""
     MINAO_AUTO_PP = SimpleKeyword("minao-auto-pp")
+    """SimpleKeyword: BasisSet."""
     MINI = SimpleKeyword("mini")
+    """SimpleKeyword: BasisSet."""
     MINIS = SimpleKeyword("minis")
+    """SimpleKeyword: BasisSet."""
     MINIX = SimpleKeyword("minix")
+    """SimpleKeyword: BasisSet."""
     OLD_DKH_SV_P = SimpleKeyword("old-dkh-sv(p)")
+    """SimpleKeyword: BasisSet."""
     OLD_DKH_SVP = SimpleKeyword("old-dkh-svp")
+    """SimpleKeyword: BasisSet."""
     OLD_DKH_TZV_P = SimpleKeyword("old-dkh-tzv(p)")
+    """SimpleKeyword: BasisSet."""
     OLD_DKH_TZVP = SimpleKeyword("old-dkh-tzvp")
+    """SimpleKeyword: BasisSet."""
     OLD_DKH_TZVPP = SimpleKeyword("old-dkh-tzvpp")
+    """SimpleKeyword: BasisSet."""
     OLD_SV = SimpleKeyword("old-sv")
+    """SimpleKeyword: BasisSet."""
     OLD_SV_P = SimpleKeyword("old-sv(p)")
+    """SimpleKeyword: BasisSet."""
     OLD_SVP = SimpleKeyword("old-svp")
+    """SimpleKeyword: BasisSet."""
     OLD_TZV = SimpleKeyword("old-tzv")
+    """SimpleKeyword: BasisSet."""
     OLD_TZV_P = SimpleKeyword("old-tzv(p)")
+    """SimpleKeyword: BasisSet."""
     OLD_TZVP = SimpleKeyword("old-tzvp")
+    """SimpleKeyword: BasisSet."""
     OLD_TZVPP = SimpleKeyword("old-tzvpp")
+    """SimpleKeyword: BasisSet."""
     OLD_ZORA_SV_P = SimpleKeyword("old-zora-sv(p)")
+    """SimpleKeyword: BasisSet."""
     OLD_ZORA_SVP = SimpleKeyword("old-zora-svp")
+    """SimpleKeyword: BasisSet."""
     OLD_ZORA_TZV_P = SimpleKeyword("old-zora-tzv(p)")
+    """SimpleKeyword: BasisSet."""
     OLD_ZORA_TZVP = SimpleKeyword("old-zora-tzvp")
+    """SimpleKeyword: BasisSet."""
     OLD_ZORA_TZVPP = SimpleKeyword("old-zora-tzvpp")
+    """SimpleKeyword: BasisSet."""
     PARTRIDGE_1 = SimpleKeyword("partridge-1")
+    """SimpleKeyword: BasisSet."""
     PARTRIDGE_2 = SimpleKeyword("partridge-2")
+    """SimpleKeyword: BasisSet."""
     PARTRIDGE_3 = SimpleKeyword("partridge-3")
+    """SimpleKeyword: BasisSet."""
     PARTRIDGE_4 = SimpleKeyword("partridge-4")
+    """SimpleKeyword: BasisSet."""
     PC_0 = SimpleKeyword("pc-0")
+    """SimpleKeyword: BasisSet."""
     PC_1 = SimpleKeyword("pc-1")
+    """SimpleKeyword: BasisSet."""
     PC_2 = SimpleKeyword("pc-2")
+    """SimpleKeyword: BasisSet."""
     PC_3 = SimpleKeyword("pc-3")
+    """SimpleKeyword: BasisSet."""
     PC_4 = SimpleKeyword("pc-4")
+    """SimpleKeyword: BasisSet."""
     PCH_1 = SimpleKeyword("pch-1")
+    """SimpleKeyword: BasisSet."""
     PCH_2 = SimpleKeyword("pch-2")
+    """SimpleKeyword: BasisSet."""
     PCH_3 = SimpleKeyword("pch-3")
+    """SimpleKeyword: BasisSet."""
     PCH_4 = SimpleKeyword("pch-4")
+    """SimpleKeyword: BasisSet."""
     PCJ_0 = SimpleKeyword("pcj-0")
+    """SimpleKeyword: BasisSet."""
     PCJ_1 = SimpleKeyword("pcj-1")
+    """SimpleKeyword: BasisSet."""
     PCJ_2 = SimpleKeyword("pcj-2")
+    """SimpleKeyword: BasisSet."""
     PCJ_3 = SimpleKeyword("pcj-3")
+    """SimpleKeyword: BasisSet."""
     PCJ_4 = SimpleKeyword("pcj-4")
+    """SimpleKeyword: BasisSet."""
     PCSEG_0 = SimpleKeyword("pcseg-0")
+    """SimpleKeyword: BasisSet."""
     PCSEG_1 = SimpleKeyword("pcseg-1")
+    """SimpleKeyword: BasisSet."""
     PCSEG_2 = SimpleKeyword("pcseg-2")
+    """SimpleKeyword: BasisSet."""
     PCSEG_3 = SimpleKeyword("pcseg-3")
+    """SimpleKeyword: BasisSet."""
     PCSEG_4 = SimpleKeyword("pcseg-4")
+    """SimpleKeyword: BasisSet."""
     PCSSEG_0 = SimpleKeyword("pcsseg-0")
+    """SimpleKeyword: BasisSet."""
     PCSSEG_1 = SimpleKeyword("pcsseg-1")
+    """SimpleKeyword: BasisSet."""
     PCSSEG_2 = SimpleKeyword("pcsseg-2")
+    """SimpleKeyword: BasisSet."""
     PCSSEG_3 = SimpleKeyword("pcsseg-3")
+    """SimpleKeyword: BasisSet."""
     PCSSEG_4 = SimpleKeyword("pcsseg-4")
+    """SimpleKeyword: BasisSet."""
     PCX_1 = SimpleKeyword("pcx-1")
+    """SimpleKeyword: BasisSet."""
     PCX_2 = SimpleKeyword("pcx-2")
+    """SimpleKeyword: BasisSet."""
     PCX_3 = SimpleKeyword("pcx-3")
+    """SimpleKeyword: BasisSet."""
     PCX_4 = SimpleKeyword("pcx-4")
+    """SimpleKeyword: BasisSet."""
     QZVP = SimpleKeyword("qzvp")
+    """SimpleKeyword: BasisSet."""
     QZVPP = SimpleKeyword("qzvpp")
+    """SimpleKeyword: BasisSet."""
     SAPPORO_DKH3_DZP_2012 = SimpleKeyword("sapporo-dkh3-dzp-2012")
+    """SimpleKeyword: BasisSet."""
     SAPPORO_DKH3_QZP_2012 = SimpleKeyword("sapporo-dkh3-qzp-2012")
+    """SimpleKeyword: BasisSet."""
     SAPPORO_DKH3_TZP_2012 = SimpleKeyword("sapporo-dkh3-tzp-2012")
+    """SimpleKeyword: BasisSet."""
     SAPPORO_DZP_2012 = SimpleKeyword("sapporo-dzp-2012")
+    """SimpleKeyword: BasisSet."""
     SAPPORO_QZP_2012 = SimpleKeyword("sapporo-qzp-2012")
+    """SimpleKeyword: BasisSet."""
     SAPPORO_TZP_2012 = SimpleKeyword("sapporo-tzp-2012")
+    """SimpleKeyword: BasisSet."""
     SARC_DKH_SVP = SimpleKeyword("sarc-dkh-svp")
+    """SimpleKeyword: BasisSet."""
     SARC_DKH_TZVP = SimpleKeyword("sarc-dkh-tzvp")
+    """SimpleKeyword: BasisSet."""
     SARC_DKH_TZVPP = SimpleKeyword("sarc-dkh-tzvpp")
+    """SimpleKeyword: BasisSet."""
     SARC_ZORA_SVP = SimpleKeyword("sarc-zora-svp")
+    """SimpleKeyword: BasisSet."""
     SARC_ZORA_TZVP = SimpleKeyword("sarc-zora-tzvp")
+    """SimpleKeyword: BasisSet."""
     SARC_ZORA_TZVPP = SimpleKeyword("sarc-zora-tzvpp")
+    """SimpleKeyword: BasisSet."""
     SARC2_DKH_QZV = SimpleKeyword("sarc2-dkh-qzv")
+    """SimpleKeyword: BasisSet."""
     SARC2_DKH_QZVP = SimpleKeyword("sarc2-dkh-qzvp")
+    """SimpleKeyword: BasisSet."""
     SARC2_ZORA_QZV = SimpleKeyword("sarc2-zora-qzv")
+    """SimpleKeyword: BasisSet."""
     SARC2_ZORA_QZVP = SimpleKeyword("sarc2-zora-qzvp")
+    """SimpleKeyword: BasisSet."""
     SAUG_ANO_PV5Z = SimpleKeyword("saug-ano-pv5z")
+    """SimpleKeyword: BasisSet."""
     SAUG_ANO_PVDZ = SimpleKeyword("saug-ano-pvdz")
+    """SimpleKeyword: BasisSet."""
     SAUG_ANO_PVQZ = SimpleKeyword("saug-ano-pvqz")
+    """SimpleKeyword: BasisSet."""
     SAUG_ANO_PVTZ = SimpleKeyword("saug-ano-pvtz")
+    """SimpleKeyword: BasisSet."""
     STO_3G = SimpleKeyword("sto-3g")
+    """SimpleKeyword: BasisSet."""
     SV = SimpleKeyword("sv")
+    """SimpleKeyword: BasisSet."""
     SV_P = SimpleKeyword("sv(p)")
+    """SimpleKeyword: BasisSet."""
     SVP = SimpleKeyword("svp")
+    """SimpleKeyword: BasisSet."""
     TZV = SimpleKeyword("tzv")
+    """SimpleKeyword: BasisSet."""
     TZV_P = SimpleKeyword("tzv(p)")
+    """SimpleKeyword: BasisSet."""
     TZVP = SimpleKeyword("tzvp")
+    """SimpleKeyword: BasisSet."""
     TZVPP = SimpleKeyword("tzvpp")
+    """SimpleKeyword: BasisSet."""
     UGBS = SimpleKeyword("ugbs")
+    """SimpleKeyword: BasisSet."""
     VDZP = SimpleKeyword("vdzp")
+    """SimpleKeyword: BasisSet."""
     W1_DZ = SimpleKeyword("w1-dz")
+    """SimpleKeyword: BasisSet."""
     W1_MTSMALL = SimpleKeyword("w1-mtsmall")
+    """SimpleKeyword: BasisSet."""
     W1_OPT = SimpleKeyword("w1-opt")
+    """SimpleKeyword: BasisSet."""
     W1_QZ = SimpleKeyword("w1-qz")
+    """SimpleKeyword: BasisSet."""
     W1_TZ = SimpleKeyword("w1-tz")
+    """SimpleKeyword: BasisSet."""
     WACHTERSPLUSF = SimpleKeyword("wachters+f")
+    """SimpleKeyword: BasisSet."""
     X2C_QZVPALL = SimpleKeyword("x2c-qzvpall")
+    """SimpleKeyword: BasisSet."""
     X2C_QZVPALL_2C = SimpleKeyword("x2c-qzvpall-2c")
+    """SimpleKeyword: BasisSet."""
     X2C_QZVPALL_2C_S = SimpleKeyword("x2c-qzvpall-2c-s")
+    """SimpleKeyword: BasisSet."""
     X2C_QZVPALL_S = SimpleKeyword("x2c-qzvpall-s")
+    """SimpleKeyword: BasisSet."""
     X2C_QZVPPALL = SimpleKeyword("x2c-qzvppall")
+    """SimpleKeyword: BasisSet."""
     X2C_QZVPPALL_2C = SimpleKeyword("x2c-qzvppall-2c")
+    """SimpleKeyword: BasisSet."""
     X2C_QZVPPALL_2C_S = SimpleKeyword("x2c-qzvppall-2c-s")
+    """SimpleKeyword: BasisSet."""
     X2C_QZVPPALL_S = SimpleKeyword("x2c-qzvppall-s")
+    """SimpleKeyword: BasisSet."""
     X2C_SV_P_ALL = SimpleKeyword("x2c-sv(p)all")
+    """SimpleKeyword: BasisSet."""
     X2C_SV_P_ALL_2C = SimpleKeyword("x2c-sv(p)all-2c")
+    """SimpleKeyword: BasisSet."""
     X2C_SV_P_ALL_S = SimpleKeyword("x2c-sv(p)all-s")
+    """SimpleKeyword: BasisSet."""
     X2C_SVPALL = SimpleKeyword("x2c-svpall")
+    """SimpleKeyword: BasisSet."""
     X2C_SVPALL_2C = SimpleKeyword("x2c-svpall-2c")
+    """SimpleKeyword: BasisSet."""
     X2C_SVPALL_S = SimpleKeyword("x2c-svpall-s")
+    """SimpleKeyword: BasisSet."""
     X2C_TZVPALL = SimpleKeyword("x2c-tzvpall")
+    """SimpleKeyword: BasisSet."""
     X2C_TZVPALL_2C = SimpleKeyword("x2c-tzvpall-2c")
+    """SimpleKeyword: BasisSet."""
     X2C_TZVPALL_S = SimpleKeyword("x2c-tzvpall-s")
+    """SimpleKeyword: BasisSet."""
     X2C_TZVPPALL = SimpleKeyword("x2c-tzvppall")
+    """SimpleKeyword: BasisSet."""
     X2C_TZVPPALL_2C = SimpleKeyword("x2c-tzvppall-2c")
+    """SimpleKeyword: BasisSet."""
     X2C_TZVPPALL_S = SimpleKeyword("x2c-tzvppall-s")
+    """SimpleKeyword: BasisSet."""
     ZORA_DEF2_QZVPP = SimpleKeyword("zora-def2-qzvpp")
+    """SimpleKeyword: BasisSet."""
     ZORA_DEF2_SV_P = SimpleKeyword("zora-def2-sv(p)")
+    """SimpleKeyword: BasisSet."""
     ZORA_DEF2_SVP = SimpleKeyword("zora-def2-svp")
+    """SimpleKeyword: BasisSet."""
     ZORA_DEF2_TZVP = SimpleKeyword("zora-def2-tzvp")
+    """SimpleKeyword: BasisSet."""
     ZORA_DEF2_TZVP_F = SimpleKeyword("zora-def2-tzvp(-f)")
+    """SimpleKeyword: BasisSet."""
     ZORA_DEF2_TZVPP = SimpleKeyword("zora-def2-tzvpp")
+    """SimpleKeyword: BasisSet."""
     ZORA_MA_DEF2_QZVPP = SimpleKeyword("zora-ma-def2-qzvpp")
+    """SimpleKeyword: BasisSet."""
     ZORA_MA_DEF2_SV_P = SimpleKeyword("zora-ma-def2-sv(p)")
+    """SimpleKeyword: BasisSet."""
     ZORA_MA_DEF2_SVP = SimpleKeyword("zora-ma-def2-svp")
+    """SimpleKeyword: BasisSet."""
     ZORA_MA_DEF2_TZVP = SimpleKeyword("zora-ma-def2-tzvp")
+    """SimpleKeyword: BasisSet."""
     ZORA_MA_DEF2_TZVP_F = SimpleKeyword("zora-ma-def2-tzvp(-f)")
+    """SimpleKeyword: BasisSet."""
     ZORA_MA_DEF2_TZVPP = SimpleKeyword("zora-ma-def2-tzvpp")
+    """SimpleKeyword: BasisSet."""
     ZORA_QZVP = SimpleKeyword("zora-qzvp")
+    """SimpleKeyword: BasisSet."""
     ZORA_QZVPP = SimpleKeyword("zora-qzvpp")
+    """SimpleKeyword: BasisSet."""
     ZORA_SV_P = SimpleKeyword("zora-sv(p)")
+    """SimpleKeyword: BasisSet."""
     ZORA_SVP = SimpleKeyword("zora-svp")
+    """SimpleKeyword: BasisSet."""
     ZORA_TZV_P = SimpleKeyword("zora-tzv(p)")
+    """SimpleKeyword: BasisSet."""
     ZORA_TZVP = SimpleKeyword("zora-tzvp")
+    """SimpleKeyword: BasisSet."""
     ZORA_TZVPP = SimpleKeyword("zora-tzvpp")
+    """SimpleKeyword: BasisSet."""

--- a/src/opi/input/simple_keywords/basis_set.py
+++ b/src/opi/input/simple_keywords/basis_set.py
@@ -7,7 +7,987 @@ __all__ = ("BasisSet",)
 
 
 class BasisSet(SimpleKeywordBox):
-    """Enum to store all simple keywords of type BasisSet"""
+    """Enum to store all simple keywords of type BasisSet.
+
+    Attributes
+    ----------
+    G3_21G : SimpleKeyword
+        BasisSet
+    G3_21GSP : SimpleKeyword
+        BasisSet
+    G4_22GSP : SimpleKeyword
+        BasisSet
+    G6_31PLUSPLUSG_2D_2P : SimpleKeyword
+        BasisSet
+    G6_31PLUSPLUSG_2D_P : SimpleKeyword
+        BasisSet
+    G6_31PLUSPLUSG_2DF_2P : SimpleKeyword
+        BasisSet
+    G6_31PLUSPLUSG_2DF_2PD : SimpleKeyword
+        BasisSet
+    G6_31PLUSPLUSG_D_P : SimpleKeyword
+        BasisSet
+    G6_31PLUSPLUSGSTARSTAR : SimpleKeyword
+        BasisSet
+    G6_31PLUSG_2D_2P : SimpleKeyword
+        BasisSet
+    G6_31PLUSG_2D_P : SimpleKeyword
+        BasisSet
+    G6_31PLUSG_2D : SimpleKeyword
+        BasisSet
+    G6_31PLUSG_2DF_2P : SimpleKeyword
+        BasisSet
+    G6_31PLUSG_2DF_2PD : SimpleKeyword
+        BasisSet
+    G6_31PLUSG_2DF : SimpleKeyword
+        BasisSet
+    G6_31PLUSG_D_P : SimpleKeyword
+        BasisSet
+    G6_31PLUSG_D : SimpleKeyword
+        BasisSet
+    G6_31PLUSGSTAR : SimpleKeyword
+        BasisSet
+    G6_31PLUSGSTARSTAR : SimpleKeyword
+        BasisSet
+    G6_311PLUSPLUSG_2D_2P : SimpleKeyword
+        BasisSet
+    G6_311PLUSPLUSG_2D_P : SimpleKeyword
+        BasisSet
+    G6_311PLUSPLUSG_2DF_2P : SimpleKeyword
+        BasisSet
+    G6_311PLUSPLUSG_2DF_2PD : SimpleKeyword
+        BasisSet
+    G6_311PLUSPLUSG_3DF_3PD : SimpleKeyword
+        BasisSet
+    G6_311PLUSPLUSG_D_P : SimpleKeyword
+        BasisSet
+    G6_311PLUSPLUSGSTARSTAR : SimpleKeyword
+        BasisSet
+    G6_311PLUSG_2D_2P : SimpleKeyword
+        BasisSet
+    G6_311PLUSG_2D_P : SimpleKeyword
+        BasisSet
+    G6_311PLUSG_2D : SimpleKeyword
+        BasisSet
+    G6_311PLUSG_2DF_2P : SimpleKeyword
+        BasisSet
+    G6_311PLUSG_2DF_2PD : SimpleKeyword
+        BasisSet
+    G6_311PLUSG_2DF : SimpleKeyword
+        BasisSet
+    G6_311PLUSG_3DF_2P : SimpleKeyword
+        BasisSet
+    G6_311PLUSG_3DF_3PD : SimpleKeyword
+        BasisSet
+    G6_311PLUSG_3DF : SimpleKeyword
+        BasisSet
+    G6_311PLUSG_D_P : SimpleKeyword
+        BasisSet
+    G6_311PLUSG_D : SimpleKeyword
+        BasisSet
+    G6_311PLUSGSTAR : SimpleKeyword
+        BasisSet
+    G6_311PLUSGSTARSTAR : SimpleKeyword
+        BasisSet
+    G6_311G : SimpleKeyword
+        BasisSet
+    G6_311G_2D_2P : SimpleKeyword
+        BasisSet
+    G6_311G_2D_P : SimpleKeyword
+        BasisSet
+    G6_311G_2D : SimpleKeyword
+        BasisSet
+    G6_311G_2DF_2P : SimpleKeyword
+        BasisSet
+    G6_311G_2DF_2PD : SimpleKeyword
+        BasisSet
+    G6_311G_2DF : SimpleKeyword
+        BasisSet
+    G6_311G_3DF_3PD : SimpleKeyword
+        BasisSet
+    G6_311G_3DF : SimpleKeyword
+        BasisSet
+    G6_311G_D_P : SimpleKeyword
+        BasisSet
+    G6_311G_D : SimpleKeyword
+        BasisSet
+    G6_311GSTAR : SimpleKeyword
+        BasisSet
+    G6_311GSTARSTAR : SimpleKeyword
+        BasisSet
+    G6_31G : SimpleKeyword
+        BasisSet
+    G6_31G_2D_2P : SimpleKeyword
+        BasisSet
+    G6_31G_2D_P : SimpleKeyword
+        BasisSet
+    G6_31G_2D : SimpleKeyword
+        BasisSet
+    G6_31G_2DF_2P : SimpleKeyword
+        BasisSet
+    G6_31G_2DF_2PD : SimpleKeyword
+        BasisSet
+    G6_31G_2DF : SimpleKeyword
+        BasisSet
+    G6_31G_D_P : SimpleKeyword
+        BasisSet
+    G6_31G_D : SimpleKeyword
+        BasisSet
+    G6_31GSTAR : SimpleKeyword
+        BasisSet
+    G6_31GSTARSTAR : SimpleKeyword
+        BasisSet
+    AHGBS_5 : SimpleKeyword
+        BasisSet
+    AHGBS_7 : SimpleKeyword
+        BasisSet
+    AHGBS_9 : SimpleKeyword
+        BasisSet
+    AHGBSP1_5 : SimpleKeyword
+        BasisSet
+    AHGBSP1_7 : SimpleKeyword
+        BasisSet
+    AHGBSP1_9 : SimpleKeyword
+        BasisSet
+    AHGBSP2_5 : SimpleKeyword
+        BasisSet
+    AHGBSP2_7 : SimpleKeyword
+        BasisSet
+    AHGBSP2_9 : SimpleKeyword
+        BasisSet
+    AHGBSP3_5 : SimpleKeyword
+        BasisSet
+    AHGBSP3_7 : SimpleKeyword
+        BasisSet
+    AHGBSP3_9 : SimpleKeyword
+        BasisSet
+    ANO_PC_0 : SimpleKeyword
+        BasisSet
+    ANO_PC_0_POL : SimpleKeyword
+        BasisSet
+    ANO_PV5Z : SimpleKeyword
+        BasisSet
+    ANO_PV6Z : SimpleKeyword
+        BasisSet
+    ANO_PVDZ : SimpleKeyword
+        BasisSet
+    ANO_PVQZ : SimpleKeyword
+        BasisSet
+    ANO_PVTZ : SimpleKeyword
+        BasisSet
+    ANO_RCC_DZP : SimpleKeyword
+        BasisSet
+    ANO_RCC_FULL : SimpleKeyword
+        BasisSet
+    ANO_RCC_MB : SimpleKeyword
+        BasisSet
+    ANO_RCC_QZP : SimpleKeyword
+        BasisSet
+    ANO_RCC_TZP : SimpleKeyword
+        BasisSet
+    ANO_SZ : SimpleKeyword
+        BasisSet
+    ANO_SZ_DKH_SMALL : SimpleKeyword
+        BasisSet
+    APR_CC_PV_QPLUSD_Z : SimpleKeyword
+        BasisSet
+    AUG_ANO_PV5Z : SimpleKeyword
+        BasisSet
+    AUG_ANO_PVDZ : SimpleKeyword
+        BasisSet
+    AUG_ANO_PVQZ : SimpleKeyword
+        BasisSet
+    AUG_ANO_PVTZ : SimpleKeyword
+        BasisSet
+    AUG_CC_PCV5Z : SimpleKeyword
+        BasisSet
+    AUG_CC_PCV5Z_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PCV6Z : SimpleKeyword
+        BasisSet
+    AUG_CC_PCVDZ : SimpleKeyword
+        BasisSet
+    AUG_CC_PCVDZ_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PCVQZ : SimpleKeyword
+        BasisSet
+    AUG_CC_PCVQZ_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PCVTZ : SimpleKeyword
+        BasisSet
+    AUG_CC_PCVTZ_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PV5_PLUSD_Z : SimpleKeyword
+        BasisSet
+    AUG_CC_PV5Z : SimpleKeyword
+        BasisSet
+    AUG_CC_PV5Z_DK : SimpleKeyword
+        BasisSet
+    AUG_CC_PV5Z_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PV5Z_PP_OPTRI : SimpleKeyword
+        BasisSet
+    AUG_CC_PV6_PLUSD_Z : SimpleKeyword
+        BasisSet
+    AUG_CC_PV6Z : SimpleKeyword
+        BasisSet
+    AUG_CC_PV7Z : SimpleKeyword
+        BasisSet
+    AUG_CC_PVD_PLUSD_Z : SimpleKeyword
+        BasisSet
+    AUG_CC_PVDZ : SimpleKeyword
+        BasisSet
+    AUG_CC_PVDZ_DK : SimpleKeyword
+        BasisSet
+    AUG_CC_PVDZ_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PVDZ_PP_OPTRI : SimpleKeyword
+        BasisSet
+    AUG_CC_PVQ_PLUSD_Z : SimpleKeyword
+        BasisSet
+    AUG_CC_PVQZ : SimpleKeyword
+        BasisSet
+    AUG_CC_PVQZ_DK : SimpleKeyword
+        BasisSet
+    AUG_CC_PVQZ_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PVQZ_PP_OPTRI : SimpleKeyword
+        BasisSet
+    AUG_CC_PVT_PLUSD_Z : SimpleKeyword
+        BasisSet
+    AUG_CC_PVTZ : SimpleKeyword
+        BasisSet
+    AUG_CC_PVTZ_DK : SimpleKeyword
+        BasisSet
+    AUG_CC_PVTZ_J : SimpleKeyword
+        BasisSet
+    AUG_CC_PVTZ_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PVTZ_PP_OPTRI : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCV5Z : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCV5Z_DK : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCV5Z_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCV5Z_PP_OPTRI : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVDZ : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVDZ_DK : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVDZ_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVDZ_PP_OPTRI : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVQZ : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVQZ_DK : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVQZ_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVQZ_PP_OPTRI : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVTZ : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVTZ_DK : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVTZ_PP : SimpleKeyword
+        BasisSet
+    AUG_CC_PWCVTZ_PP_OPTRI : SimpleKeyword
+        BasisSet
+    AUG_PC_0 : SimpleKeyword
+        BasisSet
+    AUG_PC_1 : SimpleKeyword
+        BasisSet
+    AUG_PC_2 : SimpleKeyword
+        BasisSet
+    AUG_PC_3 : SimpleKeyword
+        BasisSet
+    AUG_PC_4 : SimpleKeyword
+        BasisSet
+    AUG_PCH_1 : SimpleKeyword
+        BasisSet
+    AUG_PCH_2 : SimpleKeyword
+        BasisSet
+    AUG_PCH_3 : SimpleKeyword
+        BasisSet
+    AUG_PCH_4 : SimpleKeyword
+        BasisSet
+    AUG_PCJ_0 : SimpleKeyword
+        BasisSet
+    AUG_PCJ_1 : SimpleKeyword
+        BasisSet
+    AUG_PCJ_2 : SimpleKeyword
+        BasisSet
+    AUG_PCJ_3 : SimpleKeyword
+        BasisSet
+    AUG_PCJ_4 : SimpleKeyword
+        BasisSet
+    AUG_PCSEG_0 : SimpleKeyword
+        BasisSet
+    AUG_PCSEG_1 : SimpleKeyword
+        BasisSet
+    AUG_PCSEG_2 : SimpleKeyword
+        BasisSet
+    AUG_PCSEG_3 : SimpleKeyword
+        BasisSet
+    AUG_PCSEG_4 : SimpleKeyword
+        BasisSet
+    AUG_PCSSEG_0 : SimpleKeyword
+        BasisSet
+    AUG_PCSSEG_1 : SimpleKeyword
+        BasisSet
+    AUG_PCSSEG_2 : SimpleKeyword
+        BasisSet
+    AUG_PCSSEG_3 : SimpleKeyword
+        BasisSet
+    AUG_PCSSEG_4 : SimpleKeyword
+        BasisSet
+    AUG_PCX_1 : SimpleKeyword
+        BasisSet
+    AUG_PCX_2 : SimpleKeyword
+        BasisSet
+    AUG_PCX_3 : SimpleKeyword
+        BasisSet
+    AUG_PCX_4 : SimpleKeyword
+        BasisSet
+    CC_PCV5Z : SimpleKeyword
+        BasisSet
+    CC_PCV5Z_PP : SimpleKeyword
+        BasisSet
+    CC_PCV6Z : SimpleKeyword
+        BasisSet
+    CC_PCVDZ : SimpleKeyword
+        BasisSet
+    CC_PCVDZ_F12 : SimpleKeyword
+        BasisSet
+    CC_PCVDZ_F12_OPTRI : SimpleKeyword
+        BasisSet
+    CC_PCVDZ_PP : SimpleKeyword
+        BasisSet
+    CC_PCVQZ : SimpleKeyword
+        BasisSet
+    CC_PCVQZ_F12 : SimpleKeyword
+        BasisSet
+    CC_PCVQZ_F12_OPTRI : SimpleKeyword
+        BasisSet
+    CC_PCVQZ_PP : SimpleKeyword
+        BasisSet
+    CC_PCVTZ : SimpleKeyword
+        BasisSet
+    CC_PCVTZ_F12 : SimpleKeyword
+        BasisSet
+    CC_PCVTZ_F12_OPTRI : SimpleKeyword
+        BasisSet
+    CC_PCVTZ_PP : SimpleKeyword
+        BasisSet
+    CC_PV5_PLUSD_Z : SimpleKeyword
+        BasisSet
+    CC_PV5Z : SimpleKeyword
+        BasisSet
+    CC_PV5Z_DK : SimpleKeyword
+        BasisSet
+    CC_PV5Z_PP : SimpleKeyword
+        BasisSet
+    CC_PV6Z : SimpleKeyword
+        BasisSet
+    CC_PV7Z : SimpleKeyword
+        BasisSet
+    CC_PV8Z : SimpleKeyword
+        BasisSet
+    CC_PVD_PLUSD_Z : SimpleKeyword
+        BasisSet
+    CC_PVDZ : SimpleKeyword
+        BasisSet
+    CC_PVDZ_DK : SimpleKeyword
+        BasisSet
+    CC_PVDZ_DK3 : SimpleKeyword
+        BasisSet
+    CC_PVDZ_F12 : SimpleKeyword
+        BasisSet
+    CC_PVDZ_F12_CABS : SimpleKeyword
+        BasisSet
+    CC_PVDZ_F12_OPTRI : SimpleKeyword
+        BasisSet
+    CC_PVDZ_PP : SimpleKeyword
+        BasisSet
+    CC_PVDZ_PP_F12 : SimpleKeyword
+        BasisSet
+    CC_PVDZ_PP_F12_OPTRI : SimpleKeyword
+        BasisSet
+    CC_PVQ_PLUSD_Z : SimpleKeyword
+        BasisSet
+    CC_PVQZ : SimpleKeyword
+        BasisSet
+    CC_PVQZ_DK : SimpleKeyword
+        BasisSet
+    CC_PVQZ_DK3 : SimpleKeyword
+        BasisSet
+    CC_PVQZ_F12 : SimpleKeyword
+        BasisSet
+    CC_PVQZ_F12_CABS : SimpleKeyword
+        BasisSet
+    CC_PVQZ_F12_OPTRI : SimpleKeyword
+        BasisSet
+    CC_PVQZ_PP : SimpleKeyword
+        BasisSet
+    CC_PVQZ_PP_F12 : SimpleKeyword
+        BasisSet
+    CC_PVQZ_PP_F12_OPTRI : SimpleKeyword
+        BasisSet
+    CC_PVT_PLUSD_Z : SimpleKeyword
+        BasisSet
+    CC_PVTZ : SimpleKeyword
+        BasisSet
+    CC_PVTZ_DK : SimpleKeyword
+        BasisSet
+    CC_PVTZ_DK3 : SimpleKeyword
+        BasisSet
+    CC_PVTZ_F12 : SimpleKeyword
+        BasisSet
+    CC_PVTZ_F12_CABS : SimpleKeyword
+        BasisSet
+    CC_PVTZ_F12_OPTRI : SimpleKeyword
+        BasisSet
+    CC_PVTZ_PP : SimpleKeyword
+        BasisSet
+    CC_PVTZ_PP_F12 : SimpleKeyword
+        BasisSet
+    CC_PVTZ_PP_F12_OPTRI : SimpleKeyword
+        BasisSet
+    CC_PWCV5Z : SimpleKeyword
+        BasisSet
+    CC_PWCV5Z_DK : SimpleKeyword
+        BasisSet
+    CC_PWCV5Z_PP : SimpleKeyword
+        BasisSet
+    CC_PWCVDZ : SimpleKeyword
+        BasisSet
+    CC_PWCVDZ_DK : SimpleKeyword
+        BasisSet
+    CC_PWCVDZ_DK3 : SimpleKeyword
+        BasisSet
+    CC_PWCVDZ_PP : SimpleKeyword
+        BasisSet
+    CC_PWCVQZ : SimpleKeyword
+        BasisSet
+    CC_PWCVQZ_DK : SimpleKeyword
+        BasisSet
+    CC_PWCVQZ_DK3 : SimpleKeyword
+        BasisSet
+    CC_PWCVQZ_PP : SimpleKeyword
+        BasisSet
+    CC_PWCVTZ : SimpleKeyword
+        BasisSet
+    CC_PWCVTZ_DK : SimpleKeyword
+        BasisSet
+    CC_PWCVTZ_DK3 : SimpleKeyword
+        BasisSet
+    CC_PWCVTZ_PP : SimpleKeyword
+        BasisSet
+    CP : SimpleKeyword
+        BasisSet
+    CP_PPP : SimpleKeyword
+        BasisSet
+    CRENBL : SimpleKeyword
+        BasisSet
+    D95 : SimpleKeyword
+        BasisSet
+    D95P : SimpleKeyword
+        BasisSet
+    DEF_SV_P : SimpleKeyword
+        BasisSet
+    DEF_SVP : SimpleKeyword
+        BasisSet
+    DEF_TZVP : SimpleKeyword
+        BasisSet
+    DEF_TZVPP : SimpleKeyword
+        BasisSet
+    DEF2_MSVP : SimpleKeyword
+        BasisSet
+    DEF2_MTZVP : SimpleKeyword
+        BasisSet
+    DEF2_MTZVPP : SimpleKeyword
+        BasisSet
+    DEF2_QZVP : SimpleKeyword
+        BasisSet
+    DEF2_QZVPD : SimpleKeyword
+        BasisSet
+    DEF2_QZVPP : SimpleKeyword
+        BasisSet
+    DEF2_QZVPPD : SimpleKeyword
+        BasisSet
+    DEF2_SV_P : SimpleKeyword
+        BasisSet
+    DEF2_SVP : SimpleKeyword
+        BasisSet
+    DEF2_SVPD : SimpleKeyword
+        BasisSet
+    DEF2_TZVP : SimpleKeyword
+        BasisSet
+    DEF2_TZVP_F : SimpleKeyword
+        BasisSet
+    DEF2_TZVPD : SimpleKeyword
+        BasisSet
+    DEF2_TZVPP : SimpleKeyword
+        BasisSet
+    DEF2_TZVPPD : SimpleKeyword
+        BasisSet
+    DHF_QZVP : SimpleKeyword
+        BasisSet
+    DHF_QZVP_2C : SimpleKeyword
+        BasisSet
+    DHF_QZVPP : SimpleKeyword
+        BasisSet
+    DHF_QZVPP_2C : SimpleKeyword
+        BasisSet
+    DHF_SV_P : SimpleKeyword
+        BasisSet
+    DHF_SV_P_2C : SimpleKeyword
+        BasisSet
+    DHF_SVP : SimpleKeyword
+        BasisSet
+    DHF_SVP_2C : SimpleKeyword
+        BasisSet
+    DHF_TZVP : SimpleKeyword
+        BasisSet
+    DHF_TZVP_2C : SimpleKeyword
+        BasisSet
+    DHF_TZVPP : SimpleKeyword
+        BasisSet
+    DHF_TZVPP_2C : SimpleKeyword
+        BasisSet
+    DKH_DEF2_QZVPP : SimpleKeyword
+        BasisSet
+    DKH_DEF2_SV_P : SimpleKeyword
+        BasisSet
+    DKH_DEF2_SVP : SimpleKeyword
+        BasisSet
+    DKH_DEF2_TZVP : SimpleKeyword
+        BasisSet
+    DKH_DEF2_TZVP_F : SimpleKeyword
+        BasisSet
+    DKH_DEF2_TZVPP : SimpleKeyword
+        BasisSet
+    DKH_MA_DEF2_QZVPP : SimpleKeyword
+        BasisSet
+    DKH_MA_DEF2_SV_P : SimpleKeyword
+        BasisSet
+    DKH_MA_DEF2_SVP : SimpleKeyword
+        BasisSet
+    DKH_MA_DEF2_TZVP : SimpleKeyword
+        BasisSet
+    DKH_MA_DEF2_TZVP_F : SimpleKeyword
+        BasisSet
+    DKH_MA_DEF2_TZVPP : SimpleKeyword
+        BasisSet
+    DKH_QZVP : SimpleKeyword
+        BasisSet
+    DKH_QZVPP : SimpleKeyword
+        BasisSet
+    DKH_SV_P : SimpleKeyword
+        BasisSet
+    DKH_SVP : SimpleKeyword
+        BasisSet
+    DKH_TZV_P : SimpleKeyword
+        BasisSet
+    DKH_TZVP : SimpleKeyword
+        BasisSet
+    DKH_TZVPP : SimpleKeyword
+        BasisSet
+    EPR_II : SimpleKeyword
+        BasisSet
+    EPR_III : SimpleKeyword
+        BasisSet
+    GFN1BASIS : SimpleKeyword
+        BasisSet
+    GFN2BASIS : SimpleKeyword
+        BasisSet
+    HAV_5PLUSD_Z : SimpleKeyword
+        BasisSet
+    HAV_QPLUSD_Z : SimpleKeyword
+        BasisSet
+    HAV_TPLUSD_Z : SimpleKeyword
+        BasisSet
+    HAV5Z_PLUSD : SimpleKeyword
+        BasisSet
+    HAVQZ_PLUSD : SimpleKeyword
+        BasisSet
+    HAVTZ_PLUSD : SimpleKeyword
+        BasisSet
+    HGBS_5 : SimpleKeyword
+        BasisSet
+    HGBS_7 : SimpleKeyword
+        BasisSet
+    HGBS_9 : SimpleKeyword
+        BasisSet
+    HGBSP1_5 : SimpleKeyword
+        BasisSet
+    HGBSP1_7 : SimpleKeyword
+        BasisSet
+    HGBSP1_9 : SimpleKeyword
+        BasisSet
+    HGBSP2_5 : SimpleKeyword
+        BasisSet
+    HGBSP2_7 : SimpleKeyword
+        BasisSet
+    HGBSP2_9 : SimpleKeyword
+        BasisSet
+    HGBSP3_5 : SimpleKeyword
+        BasisSet
+    HGBSP3_7 : SimpleKeyword
+        BasisSet
+    HGBSP3_9 : SimpleKeyword
+        BasisSet
+    IGLO_II : SimpleKeyword
+        BasisSet
+    IGLO_III : SimpleKeyword
+        BasisSet
+    JUL_CC_PV_DPLUSD_Z : SimpleKeyword
+        BasisSet
+    JUL_CC_PV_QPLUSD_Z : SimpleKeyword
+        BasisSet
+    JUL_CC_PV_TPLUSD_Z : SimpleKeyword
+        BasisSet
+    JUN_CC_PV_DPLUSD_Z : SimpleKeyword
+        BasisSet
+    JUN_CC_PV_QPLUSD_Z : SimpleKeyword
+        BasisSet
+    JUN_CC_PV_TPLUSD_Z : SimpleKeyword
+        BasisSet
+    LANL08 : SimpleKeyword
+        BasisSet
+    LANL08_F : SimpleKeyword
+        BasisSet
+    LANL2DZ : SimpleKeyword
+        BasisSet
+    LANL2TZ : SimpleKeyword
+        BasisSet
+    LANL2TZ_F : SimpleKeyword
+        BasisSet
+    M6_31G : SimpleKeyword
+        BasisSet
+    M6_31GSTAR : SimpleKeyword
+        BasisSet
+    MA_DEF_TZVP : SimpleKeyword
+        BasisSet
+    MA_DEF2_MSVP : SimpleKeyword
+        BasisSet
+    MA_DEF2_QZVP : SimpleKeyword
+        BasisSet
+    MA_DEF2_QZVPP : SimpleKeyword
+        BasisSet
+    MA_DEF2_SV_P : SimpleKeyword
+        BasisSet
+    MA_DEF2_SVP : SimpleKeyword
+        BasisSet
+    MA_DEF2_TZVP : SimpleKeyword
+        BasisSet
+    MA_DEF2_TZVP_F : SimpleKeyword
+        BasisSet
+    MA_DEF2_TZVPP : SimpleKeyword
+        BasisSet
+    MA_DKH_DEF2_QZVPP : SimpleKeyword
+        BasisSet
+    MA_DKH_DEF2_SV_P : SimpleKeyword
+        BasisSet
+    MA_DKH_DEF2_SVP : SimpleKeyword
+        BasisSet
+    MA_DKH_DEF2_TZVP : SimpleKeyword
+        BasisSet
+    MA_DKH_DEF2_TZVP_F : SimpleKeyword
+        BasisSet
+    MA_DKH_DEF2_TZVPP : SimpleKeyword
+        BasisSet
+    MA_ZORA_DEF2_QZVPP : SimpleKeyword
+        BasisSet
+    MA_ZORA_DEF2_SV_P : SimpleKeyword
+        BasisSet
+    MA_ZORA_DEF2_SVP : SimpleKeyword
+        BasisSet
+    MA_ZORA_DEF2_TZVP : SimpleKeyword
+        BasisSet
+    MA_ZORA_DEF2_TZVP_F : SimpleKeyword
+        BasisSet
+    MA_ZORA_DEF2_TZVPP : SimpleKeyword
+        BasisSet
+    MAUG_CC_PV_DPLUSD_Z : SimpleKeyword
+        BasisSet
+    MAUG_CC_PV_QPLUSD_Z : SimpleKeyword
+        BasisSet
+    MAUG_CC_PV_TPLUSD_Z : SimpleKeyword
+        BasisSet
+    MAY_CC_PV_QPLUSD_Z : SimpleKeyword
+        BasisSet
+    MAY_CC_PV_TPLUSD_Z : SimpleKeyword
+        BasisSet
+    MIDI : SimpleKeyword
+        BasisSet
+    MINAO : SimpleKeyword
+        BasisSet
+    MINAO_AUTO_PP : SimpleKeyword
+        BasisSet
+    MINI : SimpleKeyword
+        BasisSet
+    MINIS : SimpleKeyword
+        BasisSet
+    MINIX : SimpleKeyword
+        BasisSet
+    OLD_DKH_SV_P : SimpleKeyword
+        BasisSet
+    OLD_DKH_SVP : SimpleKeyword
+        BasisSet
+    OLD_DKH_TZV_P : SimpleKeyword
+        BasisSet
+    OLD_DKH_TZVP : SimpleKeyword
+        BasisSet
+    OLD_DKH_TZVPP : SimpleKeyword
+        BasisSet
+    OLD_SV : SimpleKeyword
+        BasisSet
+    OLD_SV_P : SimpleKeyword
+        BasisSet
+    OLD_SVP : SimpleKeyword
+        BasisSet
+    OLD_TZV : SimpleKeyword
+        BasisSet
+    OLD_TZV_P : SimpleKeyword
+        BasisSet
+    OLD_TZVP : SimpleKeyword
+        BasisSet
+    OLD_TZVPP : SimpleKeyword
+        BasisSet
+    OLD_ZORA_SV_P : SimpleKeyword
+        BasisSet
+    OLD_ZORA_SVP : SimpleKeyword
+        BasisSet
+    OLD_ZORA_TZV_P : SimpleKeyword
+        BasisSet
+    OLD_ZORA_TZVP : SimpleKeyword
+        BasisSet
+    OLD_ZORA_TZVPP : SimpleKeyword
+        BasisSet
+    PARTRIDGE_1 : SimpleKeyword
+        BasisSet
+    PARTRIDGE_2 : SimpleKeyword
+        BasisSet
+    PARTRIDGE_3 : SimpleKeyword
+        BasisSet
+    PARTRIDGE_4 : SimpleKeyword
+        BasisSet
+    PC_0 : SimpleKeyword
+        BasisSet
+    PC_1 : SimpleKeyword
+        BasisSet
+    PC_2 : SimpleKeyword
+        BasisSet
+    PC_3 : SimpleKeyword
+        BasisSet
+    PC_4 : SimpleKeyword
+        BasisSet
+    PCH_1 : SimpleKeyword
+        BasisSet
+    PCH_2 : SimpleKeyword
+        BasisSet
+    PCH_3 : SimpleKeyword
+        BasisSet
+    PCH_4 : SimpleKeyword
+        BasisSet
+    PCJ_0 : SimpleKeyword
+        BasisSet
+    PCJ_1 : SimpleKeyword
+        BasisSet
+    PCJ_2 : SimpleKeyword
+        BasisSet
+    PCJ_3 : SimpleKeyword
+        BasisSet
+    PCJ_4 : SimpleKeyword
+        BasisSet
+    PCSEG_0 : SimpleKeyword
+        BasisSet
+    PCSEG_1 : SimpleKeyword
+        BasisSet
+    PCSEG_2 : SimpleKeyword
+        BasisSet
+    PCSEG_3 : SimpleKeyword
+        BasisSet
+    PCSEG_4 : SimpleKeyword
+        BasisSet
+    PCSSEG_0 : SimpleKeyword
+        BasisSet
+    PCSSEG_1 : SimpleKeyword
+        BasisSet
+    PCSSEG_2 : SimpleKeyword
+        BasisSet
+    PCSSEG_3 : SimpleKeyword
+        BasisSet
+    PCSSEG_4 : SimpleKeyword
+        BasisSet
+    PCX_1 : SimpleKeyword
+        BasisSet
+    PCX_2 : SimpleKeyword
+        BasisSet
+    PCX_3 : SimpleKeyword
+        BasisSet
+    PCX_4 : SimpleKeyword
+        BasisSet
+    QZVP : SimpleKeyword
+        BasisSet
+    QZVPP : SimpleKeyword
+        BasisSet
+    SAPPORO_DKH3_DZP_2012 : SimpleKeyword
+        BasisSet
+    SAPPORO_DKH3_QZP_2012 : SimpleKeyword
+        BasisSet
+    SAPPORO_DKH3_TZP_2012 : SimpleKeyword
+        BasisSet
+    SAPPORO_DZP_2012 : SimpleKeyword
+        BasisSet
+    SAPPORO_QZP_2012 : SimpleKeyword
+        BasisSet
+    SAPPORO_TZP_2012 : SimpleKeyword
+        BasisSet
+    SARC_DKH_SVP : SimpleKeyword
+        BasisSet
+    SARC_DKH_TZVP : SimpleKeyword
+        BasisSet
+    SARC_DKH_TZVPP : SimpleKeyword
+        BasisSet
+    SARC_ZORA_SVP : SimpleKeyword
+        BasisSet
+    SARC_ZORA_TZVP : SimpleKeyword
+        BasisSet
+    SARC_ZORA_TZVPP : SimpleKeyword
+        BasisSet
+    SARC2_DKH_QZV : SimpleKeyword
+        BasisSet
+    SARC2_DKH_QZVP : SimpleKeyword
+        BasisSet
+    SARC2_ZORA_QZV : SimpleKeyword
+        BasisSet
+    SARC2_ZORA_QZVP : SimpleKeyword
+        BasisSet
+    SAUG_ANO_PV5Z : SimpleKeyword
+        BasisSet
+    SAUG_ANO_PVDZ : SimpleKeyword
+        BasisSet
+    SAUG_ANO_PVQZ : SimpleKeyword
+        BasisSet
+    SAUG_ANO_PVTZ : SimpleKeyword
+        BasisSet
+    STO_3G : SimpleKeyword
+        BasisSet
+    SV : SimpleKeyword
+        BasisSet
+    SV_P : SimpleKeyword
+        BasisSet
+    SVP : SimpleKeyword
+        BasisSet
+    TZV : SimpleKeyword
+        BasisSet
+    TZV_P : SimpleKeyword
+        BasisSet
+    TZVP : SimpleKeyword
+        BasisSet
+    TZVPP : SimpleKeyword
+        BasisSet
+    UGBS : SimpleKeyword
+        BasisSet
+    VDZP : SimpleKeyword
+        BasisSet
+    W1_DZ : SimpleKeyword
+        BasisSet
+    W1_MTSMALL : SimpleKeyword
+        BasisSet
+    W1_OPT : SimpleKeyword
+        BasisSet
+    W1_QZ : SimpleKeyword
+        BasisSet
+    W1_TZ : SimpleKeyword
+        BasisSet
+    WACHTERSPLUSF : SimpleKeyword
+        BasisSet
+    X2C_QZVPALL : SimpleKeyword
+        BasisSet
+    X2C_QZVPALL_2C : SimpleKeyword
+        BasisSet
+    X2C_QZVPALL_2C_S : SimpleKeyword
+        BasisSet
+    X2C_QZVPALL_S : SimpleKeyword
+        BasisSet
+    X2C_QZVPPALL : SimpleKeyword
+        BasisSet
+    X2C_QZVPPALL_2C : SimpleKeyword
+        BasisSet
+    X2C_QZVPPALL_2C_S : SimpleKeyword
+        BasisSet
+    X2C_QZVPPALL_S : SimpleKeyword
+        BasisSet
+    X2C_SV_P_ALL : SimpleKeyword
+        BasisSet
+    X2C_SV_P_ALL_2C : SimpleKeyword
+        BasisSet
+    X2C_SV_P_ALL_S : SimpleKeyword
+        BasisSet
+    X2C_SVPALL : SimpleKeyword
+        BasisSet
+    X2C_SVPALL_2C : SimpleKeyword
+        BasisSet
+    X2C_SVPALL_S : SimpleKeyword
+        BasisSet
+    X2C_TZVPALL : SimpleKeyword
+        BasisSet
+    X2C_TZVPALL_2C : SimpleKeyword
+        BasisSet
+    X2C_TZVPALL_S : SimpleKeyword
+        BasisSet
+    X2C_TZVPPALL : SimpleKeyword
+        BasisSet
+    X2C_TZVPPALL_2C : SimpleKeyword
+        BasisSet
+    X2C_TZVPPALL_S : SimpleKeyword
+        BasisSet
+    ZORA_DEF2_QZVPP : SimpleKeyword
+        BasisSet
+    ZORA_DEF2_SV_P : SimpleKeyword
+        BasisSet
+    ZORA_DEF2_SVP : SimpleKeyword
+        BasisSet
+    ZORA_DEF2_TZVP : SimpleKeyword
+        BasisSet
+    ZORA_DEF2_TZVP_F : SimpleKeyword
+        BasisSet
+    ZORA_DEF2_TZVPP : SimpleKeyword
+        BasisSet
+    ZORA_MA_DEF2_QZVPP : SimpleKeyword
+        BasisSet
+    ZORA_MA_DEF2_SV_P : SimpleKeyword
+        BasisSet
+    ZORA_MA_DEF2_SVP : SimpleKeyword
+        BasisSet
+    ZORA_MA_DEF2_TZVP : SimpleKeyword
+        BasisSet
+    ZORA_MA_DEF2_TZVP_F : SimpleKeyword
+        BasisSet
+    ZORA_MA_DEF2_TZVPP : SimpleKeyword
+        BasisSet
+    ZORA_QZVP : SimpleKeyword
+        BasisSet
+    ZORA_QZVPP : SimpleKeyword
+        BasisSet
+    ZORA_SV_P : SimpleKeyword
+        BasisSet
+    ZORA_SVP : SimpleKeyword
+        BasisSet
+    ZORA_TZV_P : SimpleKeyword
+        BasisSet
+    ZORA_TZVP : SimpleKeyword
+        BasisSet
+    ZORA_TZVPP : SimpleKeyword
+        BasisSet
+    """
 
     G3_21G = SimpleKeyword("3-21g")
     G3_21GSP = SimpleKeyword("3-21gsp")

--- a/src/opi/input/simple_keywords/basisoption.py
+++ b/src/opi/input/simple_keywords/basisoption.py
@@ -7,35 +7,99 @@ __all__ = ("BasisOption",)
 
 
 class BasisOption(SimpleKeywordBox):
-    """Enum to store all simple keywords of type BasisOption"""
+    """Enum to store all simple keywords of type BasisOption.
 
-    ANOBASIS = SimpleKeyword("anobasis")  # Modifies a selected basis
-    DECONTRACT = SimpleKeyword("decontract")  # Modifies a selected basis
-    DECONTRACTAUX = SimpleKeyword("decontractaux")  # Modifies a selected basis
-    DECONTRACTAUXC = SimpleKeyword("decontractauxc")  # Modifies a selected basis
-    DECONTRACTAUXJ = SimpleKeyword("decontractauxj")  # Modifies a selected basis
-    DECONTRACTAUXJK = SimpleKeyword("decontractauxjk")  # Modifies a selected basis
-    DECONTRACTBAS = SimpleKeyword("decontractbas")  # Modifies a selected basis
-    DECONTRACTCABS = SimpleKeyword("decontractcabs")  # Modifies a selected basis
-    NOANOBASIS = SimpleKeyword("noanobasis")  # Modifies a selected basis
-    NODECONTRACT = SimpleKeyword("nodecontract")  # Modifies a selected basis
-    NODECONTRACTAUX = SimpleKeyword("nodecontractaux")  # Modifies a selected basis
-    NODECONTRACTAUXC = SimpleKeyword("nodecontractauxc")  # Modifies a selected basis
-    NODECONTRACTAUXJ = SimpleKeyword("nodecontractauxj")  # Modifies a selected basis
-    NODECONTRACTAUXJK = SimpleKeyword("nodecontractauxjk")  # Modifies a selected basis
-    NODECONTRACTBAS = SimpleKeyword("nodecontractbas")  # Modifies a selected basis
-    NODECONTRACTCABS = SimpleKeyword("nodecontractcabs")  # Modifies a selected basis
-    NOUNCONTRACT = SimpleKeyword("nouncontract")  # Modifies a selected basis
-    NOUNCONTRACTAUX = SimpleKeyword("nouncontractaux")  # Modifies a selected basis
-    NOUNCONTRACTAUXC = SimpleKeyword("nouncontractauxc")  # Modifies a selected basis
-    NOUNCONTRACTAUXJ = SimpleKeyword("nouncontractauxj")  # Modifies a selected basis
-    NOUNCONTRACTAUXJK = SimpleKeyword("nouncontractauxjk")  # Modifies a selected basis
-    NOUNCONTRACTBAS = SimpleKeyword("nouncontractbas")  # Modifies a selected basis
-    NOUNCONTRACTCABS = SimpleKeyword("nouncontractcabs")  # Modifies a selected basis
-    UNCONTRACT = SimpleKeyword("uncontract")  # Modifies a selected basis
-    UNCONTRACTAUX = SimpleKeyword("uncontractaux")  # Modifies a selected basis
-    UNCONTRACTAUXC = SimpleKeyword("uncontractauxc")  # Modifies a selected basis
-    UNCONTRACTAUXJ = SimpleKeyword("uncontractauxj")  # Modifies a selected basis
-    UNCONTRACTAUXJK = SimpleKeyword("uncontractauxjk")  # Modifies a selected basis
-    UNCONTRACTBAS = SimpleKeyword("uncontractbas")  # Modifies a selected basis
-    UNCONTRACTCABS = SimpleKeyword("uncontractcabs")  # Modifies a selected basis
+    Attributes
+    ----------
+    ANOBASIS : SimpleKeyword
+        Modifies a selected basis
+    DECONTRACT : SimpleKeyword
+        Modifies a selected basis
+    DECONTRACTAUX : SimpleKeyword
+        Modifies a selected basis
+    DECONTRACTAUXC : SimpleKeyword
+        Modifies a selected basis
+    DECONTRACTAUXJ : SimpleKeyword
+        Modifies a selected basis
+    DECONTRACTAUXJK : SimpleKeyword
+        Modifies a selected basis
+    DECONTRACTBAS : SimpleKeyword
+        Modifies a selected basis
+    DECONTRACTCABS : SimpleKeyword
+        Modifies a selected basis
+    NOANOBASIS : SimpleKeyword
+        Modifies a selected basis
+    NODECONTRACT : SimpleKeyword
+        Modifies a selected basis
+    NODECONTRACTAUX : SimpleKeyword
+        Modifies a selected basis
+    NODECONTRACTAUXC : SimpleKeyword
+        Modifies a selected basis
+    NODECONTRACTAUXJ : SimpleKeyword
+        Modifies a selected basis
+    NODECONTRACTAUXJK : SimpleKeyword
+        Modifies a selected basis
+    NODECONTRACTBAS : SimpleKeyword
+        Modifies a selected basis
+    NODECONTRACTCABS : SimpleKeyword
+        Modifies a selected basis
+    NOUNCONTRACT : SimpleKeyword
+        Modifies a selected basis
+    NOUNCONTRACTAUX : SimpleKeyword
+        Modifies a selected basis
+    NOUNCONTRACTAUXC : SimpleKeyword
+        Modifies a selected basis
+    NOUNCONTRACTAUXJ : SimpleKeyword
+        Modifies a selected basis
+    NOUNCONTRACTAUXJK : SimpleKeyword
+        Modifies a selected basis
+    NOUNCONTRACTBAS : SimpleKeyword
+        Modifies a selected basis
+    NOUNCONTRACTCABS : SimpleKeyword
+        Modifies a selected basis
+    UNCONTRACT : SimpleKeyword
+        Modifies a selected basis
+    UNCONTRACTAUX : SimpleKeyword
+        Modifies a selected basis
+    UNCONTRACTAUXC : SimpleKeyword
+        Modifies a selected basis
+    UNCONTRACTAUXJ : SimpleKeyword
+        Modifies a selected basis
+    UNCONTRACTAUXJK : SimpleKeyword
+        Modifies a selected basis
+    UNCONTRACTBAS : SimpleKeyword
+        Modifies a selected basis
+    UNCONTRACTCABS : SimpleKeyword
+        Modifies a selected basis
+    """
+
+    ANOBASIS = SimpleKeyword("anobasis")
+    DECONTRACT = SimpleKeyword("decontract")
+    DECONTRACTAUX = SimpleKeyword("decontractaux")
+    DECONTRACTAUXC = SimpleKeyword("decontractauxc")
+    DECONTRACTAUXJ = SimpleKeyword("decontractauxj")
+    DECONTRACTAUXJK = SimpleKeyword("decontractauxjk")
+    DECONTRACTBAS = SimpleKeyword("decontractbas")
+    DECONTRACTCABS = SimpleKeyword("decontractcabs")
+    NOANOBASIS = SimpleKeyword("noanobasis")
+    NODECONTRACT = SimpleKeyword("nodecontract")
+    NODECONTRACTAUX = SimpleKeyword("nodecontractaux")
+    NODECONTRACTAUXC = SimpleKeyword("nodecontractauxc")
+    NODECONTRACTAUXJ = SimpleKeyword("nodecontractauxj")
+    NODECONTRACTAUXJK = SimpleKeyword("nodecontractauxjk")
+    NODECONTRACTBAS = SimpleKeyword("nodecontractbas")
+    NODECONTRACTCABS = SimpleKeyword("nodecontractcabs")
+    NOUNCONTRACT = SimpleKeyword("nouncontract")
+    NOUNCONTRACTAUX = SimpleKeyword("nouncontractaux")
+    NOUNCONTRACTAUXC = SimpleKeyword("nouncontractauxc")
+    NOUNCONTRACTAUXJ = SimpleKeyword("nouncontractauxj")
+    NOUNCONTRACTAUXJK = SimpleKeyword("nouncontractauxjk")
+    NOUNCONTRACTBAS = SimpleKeyword("nouncontractbas")
+    NOUNCONTRACTCABS = SimpleKeyword("nouncontractcabs")
+    UNCONTRACT = SimpleKeyword("uncontract")
+    UNCONTRACTAUX = SimpleKeyword("uncontractaux")
+    UNCONTRACTAUXC = SimpleKeyword("uncontractauxc")
+    UNCONTRACTAUXJ = SimpleKeyword("uncontractauxj")
+    UNCONTRACTAUXJK = SimpleKeyword("uncontractauxjk")
+    UNCONTRACTBAS = SimpleKeyword("uncontractbas")
+    UNCONTRACTCABS = SimpleKeyword("uncontractcabs")

--- a/src/opi/input/simple_keywords/basisoption.py
+++ b/src/opi/input/simple_keywords/basisoption.py
@@ -7,99 +7,65 @@ __all__ = ("BasisOption",)
 
 
 class BasisOption(SimpleKeywordBox):
-    """Enum to store all simple keywords of type BasisOption.
-
-    Attributes
-    ----------
-    ANOBASIS : SimpleKeyword
-        Modifies a selected basis
-    DECONTRACT : SimpleKeyword
-        Modifies a selected basis
-    DECONTRACTAUX : SimpleKeyword
-        Modifies a selected basis
-    DECONTRACTAUXC : SimpleKeyword
-        Modifies a selected basis
-    DECONTRACTAUXJ : SimpleKeyword
-        Modifies a selected basis
-    DECONTRACTAUXJK : SimpleKeyword
-        Modifies a selected basis
-    DECONTRACTBAS : SimpleKeyword
-        Modifies a selected basis
-    DECONTRACTCABS : SimpleKeyword
-        Modifies a selected basis
-    NOANOBASIS : SimpleKeyword
-        Modifies a selected basis
-    NODECONTRACT : SimpleKeyword
-        Modifies a selected basis
-    NODECONTRACTAUX : SimpleKeyword
-        Modifies a selected basis
-    NODECONTRACTAUXC : SimpleKeyword
-        Modifies a selected basis
-    NODECONTRACTAUXJ : SimpleKeyword
-        Modifies a selected basis
-    NODECONTRACTAUXJK : SimpleKeyword
-        Modifies a selected basis
-    NODECONTRACTBAS : SimpleKeyword
-        Modifies a selected basis
-    NODECONTRACTCABS : SimpleKeyword
-        Modifies a selected basis
-    NOUNCONTRACT : SimpleKeyword
-        Modifies a selected basis
-    NOUNCONTRACTAUX : SimpleKeyword
-        Modifies a selected basis
-    NOUNCONTRACTAUXC : SimpleKeyword
-        Modifies a selected basis
-    NOUNCONTRACTAUXJ : SimpleKeyword
-        Modifies a selected basis
-    NOUNCONTRACTAUXJK : SimpleKeyword
-        Modifies a selected basis
-    NOUNCONTRACTBAS : SimpleKeyword
-        Modifies a selected basis
-    NOUNCONTRACTCABS : SimpleKeyword
-        Modifies a selected basis
-    UNCONTRACT : SimpleKeyword
-        Modifies a selected basis
-    UNCONTRACTAUX : SimpleKeyword
-        Modifies a selected basis
-    UNCONTRACTAUXC : SimpleKeyword
-        Modifies a selected basis
-    UNCONTRACTAUXJ : SimpleKeyword
-        Modifies a selected basis
-    UNCONTRACTAUXJK : SimpleKeyword
-        Modifies a selected basis
-    UNCONTRACTBAS : SimpleKeyword
-        Modifies a selected basis
-    UNCONTRACTCABS : SimpleKeyword
-        Modifies a selected basis
-    """
+    """Enum to store all simple keywords of type BasisOption."""
 
     ANOBASIS = SimpleKeyword("anobasis")
+    """SimpleKeyword: Modifies a selected basis."""
     DECONTRACT = SimpleKeyword("decontract")
+    """SimpleKeyword: Modifies a selected basis."""
     DECONTRACTAUX = SimpleKeyword("decontractaux")
+    """SimpleKeyword: Modifies a selected basis."""
     DECONTRACTAUXC = SimpleKeyword("decontractauxc")
+    """SimpleKeyword: Modifies a selected basis."""
     DECONTRACTAUXJ = SimpleKeyword("decontractauxj")
+    """SimpleKeyword: Modifies a selected basis."""
     DECONTRACTAUXJK = SimpleKeyword("decontractauxjk")
+    """SimpleKeyword: Modifies a selected basis."""
     DECONTRACTBAS = SimpleKeyword("decontractbas")
+    """SimpleKeyword: Modifies a selected basis."""
     DECONTRACTCABS = SimpleKeyword("decontractcabs")
+    """SimpleKeyword: Modifies a selected basis."""
     NOANOBASIS = SimpleKeyword("noanobasis")
+    """SimpleKeyword: Modifies a selected basis."""
     NODECONTRACT = SimpleKeyword("nodecontract")
+    """SimpleKeyword: Modifies a selected basis."""
     NODECONTRACTAUX = SimpleKeyword("nodecontractaux")
+    """SimpleKeyword: Modifies a selected basis."""
     NODECONTRACTAUXC = SimpleKeyword("nodecontractauxc")
+    """SimpleKeyword: Modifies a selected basis."""
     NODECONTRACTAUXJ = SimpleKeyword("nodecontractauxj")
+    """SimpleKeyword: Modifies a selected basis."""
     NODECONTRACTAUXJK = SimpleKeyword("nodecontractauxjk")
+    """SimpleKeyword: Modifies a selected basis."""
     NODECONTRACTBAS = SimpleKeyword("nodecontractbas")
+    """SimpleKeyword: Modifies a selected basis."""
     NODECONTRACTCABS = SimpleKeyword("nodecontractcabs")
+    """SimpleKeyword: Modifies a selected basis."""
     NOUNCONTRACT = SimpleKeyword("nouncontract")
+    """SimpleKeyword: Modifies a selected basis."""
     NOUNCONTRACTAUX = SimpleKeyword("nouncontractaux")
+    """SimpleKeyword: Modifies a selected basis."""
     NOUNCONTRACTAUXC = SimpleKeyword("nouncontractauxc")
+    """SimpleKeyword: Modifies a selected basis."""
     NOUNCONTRACTAUXJ = SimpleKeyword("nouncontractauxj")
+    """SimpleKeyword: Modifies a selected basis."""
     NOUNCONTRACTAUXJK = SimpleKeyword("nouncontractauxjk")
+    """SimpleKeyword: Modifies a selected basis."""
     NOUNCONTRACTBAS = SimpleKeyword("nouncontractbas")
+    """SimpleKeyword: Modifies a selected basis."""
     NOUNCONTRACTCABS = SimpleKeyword("nouncontractcabs")
+    """SimpleKeyword: Modifies a selected basis."""
     UNCONTRACT = SimpleKeyword("uncontract")
+    """SimpleKeyword: Modifies a selected basis."""
     UNCONTRACTAUX = SimpleKeyword("uncontractaux")
+    """SimpleKeyword: Modifies a selected basis."""
     UNCONTRACTAUXC = SimpleKeyword("uncontractauxc")
+    """SimpleKeyword: Modifies a selected basis."""
     UNCONTRACTAUXJ = SimpleKeyword("uncontractauxj")
+    """SimpleKeyword: Modifies a selected basis."""
     UNCONTRACTAUXJK = SimpleKeyword("uncontractauxjk")
+    """SimpleKeyword: Modifies a selected basis."""
     UNCONTRACTBAS = SimpleKeyword("uncontractbas")
+    """SimpleKeyword: Modifies a selected basis."""
     UNCONTRACTCABS = SimpleKeyword("uncontractcabs")
+    """SimpleKeyword: Modifies a selected basis."""

--- a/src/opi/input/simple_keywords/dft.py
+++ b/src/opi/input/simple_keywords/dft.py
@@ -7,599 +7,398 @@ __all__ = ("Dft",)
 
 
 class Dft(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Dft.
-
-    Attributes
-    ----------
-    B3LYP3C : SimpleKeyword
-        DFT 3c methods, does not require dispersion correction or basis set separately
-    B973C : SimpleKeyword
-        DFT 3c methods, does not require dispersion correction or basis set separately
-    PBEH3C : SimpleKeyword
-        DFT 3c methods, does not require dispersion correction or basis set separately
-    WB97X3C : SimpleKeyword
-        DFT 3c methods, does not require dispersion correction or basis set separately
-    B3LYP_GCP_D3_6_31G_D : SimpleKeyword
-        Dft
-    B3LYP_GCP_D3_6_31GSTAR : SimpleKeyword
-        DFT - similar to 3c methods, does not require dispersion correction or basis set separately
-    FOD : SimpleKeyword
-        DFT with smearing for determining multireference character (TPSS/def2-TZVP, T = 5000 K)
-    B1LYP : SimpleKeyword
-        DFT functional
-    B1P : SimpleKeyword
-        DFT functional
-    B1P86 : SimpleKeyword
-        DFT functional
-    B1PBE : SimpleKeyword
-        DFT functional
-    B1PW : SimpleKeyword
-        DFT functional
-    B1PW91 : SimpleKeyword
-        DFT functional
-    B2GP_PLYP : SimpleKeyword
-        DFT functional
-    B2K_PLYP : SimpleKeyword
-        DFT functional
-    B2PLYP : SimpleKeyword
-        DFT functional
-    B2T_PLYP : SimpleKeyword
-        DFT functional
-    B3LYP : SimpleKeyword
-        DFT functional
-    B3LYP_G : SimpleKeyword
-        DFT functional
-    B3P : SimpleKeyword
-        DFT functional
-    B3P86 : SimpleKeyword
-        DFT functional
-    B3PBE : SimpleKeyword
-        DFT functional
-    B3PW : SimpleKeyword
-        DFT functional
-    B3PW91 : SimpleKeyword
-        DFT functional
-    B97 : SimpleKeyword
-        DFT functional
-    B97_D : SimpleKeyword
-        DFT functional
-    B97_D3 : SimpleKeyword
-        DFT functional
-    B97_D4 : SimpleKeyword
-        DFT functional
-    B97M_D3BJ : SimpleKeyword
-        DFT functional
-    B97M_D4 : SimpleKeyword
-        DFT functional
-    B97M_V : SimpleKeyword
-        DFT functional
-    BHANDHLYP : SimpleKeyword
-        DFT functional
-    BHLYP : SimpleKeyword
-        DFT functional
-    BLYP : SimpleKeyword
-        DFT functional
-    BNULL : SimpleKeyword
-        DFT functional
-    BP86 : SimpleKeyword
-        DFT functional
-    BPBE : SimpleKeyword
-        DFT functional
-    BPW : SimpleKeyword
-        DFT functional
-    BPW91 : SimpleKeyword
-        DFT functional
-    BVWN : SimpleKeyword
-        DFT functional
-    CAM_B3LYP : SimpleKeyword
-        DFT functional
-    DLPNO_B2GP_PLYP : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_B2K_PLYP : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_B2PLYP : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_B2T_PLYP : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_DSD_BLYP : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_DSD_PBEB95 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_DSD_PBEP86 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_KPR2SCAN50 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_MPW2PLYP : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_PBE_QIDH : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_PBE0_2 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_PBE0_DH : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_PR2SCAN50 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_PR2SCAN69 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_PWPB95 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_R2SCAN_CIDH : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_R2SCAN_QIDH : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_R2SCAN0_2 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_R2SCAN0_DH : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_RSX_0DH : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_RSX_QIDH : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_B2GP_PLYP21 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_PBE_QIDH : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_RSX_QIDH : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_WB2GP_PLYP : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_WB88PP86 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_WPBEPP86 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_SOS_B2PLYP21 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_SOS_WB2PLYP : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_B2GP_PLYP21 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_PBE_QIDH : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_RSX_QIDH : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_WB2GP_PLYP : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_WB88PP86 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_WPBEPP86 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_WB2GP_PLYP : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_WB2PLYP : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_WB88PP86 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_WB97M_2 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_WB97X_2 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_WB97X_2_TQZ : SimpleKeyword
-        Dft
-    DLPNO_WPBEPP86 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DLPNO_WPR2SCAN50 : SimpleKeyword
-        Double-hybrid DFT with DLPNO approximation
-    DSD_BLYP : SimpleKeyword
-        DFT functional
-    DSD_PBEB95 : SimpleKeyword
-        DFT functional
-    DSD_PBEP86 : SimpleKeyword
-        DFT functional
-    G1LYP : SimpleKeyword
-        DFT functional
-    G1P : SimpleKeyword
-        DFT functional
-    G3LYP : SimpleKeyword
-        DFT functional
-    G3P : SimpleKeyword
-        DFT functional
-    GLYP : SimpleKeyword
-        DFT functional
-    GP : SimpleKeyword
-        DFT functional
-    HFLDA : SimpleKeyword
-        DFT functional
-    HFS : SimpleKeyword
-        DFT functional
-    KPR2SCAN50 : SimpleKeyword
-        DFT functional
-    LB94 : SimpleKeyword
-        DFT functional
-    LC_BLYP : SimpleKeyword
-        DFT functional
-    LC_PBE : SimpleKeyword
-        DFT functional
-    LDA : SimpleKeyword
-        DFT functional
-    LRC_PBE : SimpleKeyword
-        DFT functional
-    LSD : SimpleKeyword
-        DFT functional
-    M06 : SimpleKeyword
-        DFT functional
-    M062X : SimpleKeyword
-        DFT functional
-    M06L : SimpleKeyword
-        DFT functional
-    MPW1LYP : SimpleKeyword
-        DFT functional
-    MPW1PW : SimpleKeyword
-        DFT functional
-    MPW2PLYP : SimpleKeyword
-        DFT functional
-    MPWLYP : SimpleKeyword
-        DFT functional
-    MPWPW : SimpleKeyword
-        DFT functional
-    O3LYP : SimpleKeyword
-        DFT functional
-    OLYP : SimpleKeyword
-        DFT functional
-    OPBE : SimpleKeyword
-        DFT functional
-    PBE : SimpleKeyword
-        DFT functional
-    PBE_QIDH : SimpleKeyword
-        DFT functional
-    PBE0 : SimpleKeyword
-        DFT functional
-    PBE0_2 : SimpleKeyword
-        DFT functional
-    PBE0_DH : SimpleKeyword
-        DFT functional
-    PR2SCAN50 : SimpleKeyword
-        DFT functional
-    PR2SCAN69 : SimpleKeyword
-        DFT functional
-    PW1PW : SimpleKeyword
-        DFT functional
-    PW6B95 : SimpleKeyword
-        DFT functional
-    PW86PBE : SimpleKeyword
-        DFT functional
-    PW91 : SimpleKeyword
-        DFT functional
-    PW91_0 : SimpleKeyword
-        DFT functional
-    PWLDA : SimpleKeyword
-        DFT functional
-    PWP : SimpleKeyword
-        DFT functional
-    PWP1 : SimpleKeyword
-        DFT functional
-    PWPB95 : SimpleKeyword
-        DFT functional
-    R2SCAN : SimpleKeyword
-        DFT functional
-    R2SCAN_3C : SimpleKeyword
-        DFT functional
-    R2SCAN_CIDH : SimpleKeyword
-        DFT functional
-    R2SCAN_QIDH : SimpleKeyword
-        DFT functional
-    R2SCAN0 : SimpleKeyword
-        DFT functional
-    R2SCAN0 : SimpleKeyword
-        DFT functional
-    R2SCAN0_2 : SimpleKeyword
-        DFT functional
-    R2SCAN0_DH : SimpleKeyword
-        DFT functional
-    R2SCAN50 : SimpleKeyword
-        DFT functional
-    R2SCANH : SimpleKeyword
-        DFT functional
-    REVDOD_PBEP86_D4_2021 : SimpleKeyword
-        DFT functional
-    REVDOD_PBEP86_2021 : SimpleKeyword
-        DFT functional
-    REVDSD_PBEP86_D4_2021 : SimpleKeyword
-        DFT functional
-    REVDSD_PBEP86_2021 : SimpleKeyword
-        DFT functional
-    REVPBE : SimpleKeyword
-        DFT functional
-    REVPBE0 : SimpleKeyword
-        DFT functional
-    REVPBE38 : SimpleKeyword
-        DFT functional
-    REVTPSS : SimpleKeyword
-        DFT functional
-    RPBE : SimpleKeyword
-        DFT functional
-    RPW86PBE : SimpleKeyword
-        DFT functional
-    RSCAN : SimpleKeyword
-        DFT functional
-    RSX_0DH : SimpleKeyword
-        DFT functional
-    RSX_QIDH : SimpleKeyword
-        DFT functional
-    SCANFUNC : SimpleKeyword
-        DFT functional
-    SCS_B2GP_PLYP21 : SimpleKeyword
-        DFT functional
-    SCS_PBE_QIDH : SimpleKeyword
-        DFT functional
-    SCS_RSX_QIDH : SimpleKeyword
-        DFT functional
-    SCS_WB2GP_PLYP : SimpleKeyword
-        DFT functional
-    SCS_WB88PP86 : SimpleKeyword
-        DFT functional
-    SCS_WPBEPP86 : SimpleKeyword
-        DFT functional
-    SCS_SOS_B2PLYP21 : SimpleKeyword
-        DFT functional
-    SCS_SOS_WB2PLYP : SimpleKeyword
-        DFT functional
-    SOS_B2GP_PLYP21 : SimpleKeyword
-        DFT functional
-    SOS_PBE_QIDH : SimpleKeyword
-        DFT functional
-    SOS_RSX_QIDH : SimpleKeyword
-        DFT functional
-    SOS_WB2GP_PLYP : SimpleKeyword
-        DFT functional
-    SOS_WB88PP86 : SimpleKeyword
-        DFT functional
-    SOS_WPBEPP86 : SimpleKeyword
-        DFT functional
-    TPSS : SimpleKeyword
-        DFT functional
-    TPSS0 : SimpleKeyword
-        DFT functional
-    TPSSH : SimpleKeyword
-        DFT functional
-    VWN : SimpleKeyword
-        DFT functional
-    VWN3 : SimpleKeyword
-        DFT functional
-    VWN5 : SimpleKeyword
-        DFT functional
-    WB2GP_PLYP : SimpleKeyword
-        DFT functional
-    WB2PLYP : SimpleKeyword
-        DFT functional
-    WB88PP86 : SimpleKeyword
-        DFT functional
-    WB97 : SimpleKeyword
-        DFT functional
-    WB97M_D3BJ : SimpleKeyword
-        DFT functional
-    WB97M_D4 : SimpleKeyword
-        DFT functional
-    WB97M_D4REV : SimpleKeyword
-        DFT functional
-    WB97M_V : SimpleKeyword
-        DFT functional
-    WB97M_2 : SimpleKeyword
-        DFT functional
-    WB97X : SimpleKeyword
-        DFT functional
-    WB97X_2 : SimpleKeyword
-        DFT functional
-    WB97X_2_TQZ : SimpleKeyword
-        DFT functional
-    WB97X_D3 : SimpleKeyword
-        DFT functional
-    WB97X_D3BJ : SimpleKeyword
-        DFT functional
-    WB97X_D4 : SimpleKeyword
-        DFT functional
-    WB97X_D4REV : SimpleKeyword
-        DFT functional
-    WB97X_V : SimpleKeyword
-        DFT functional
-    WPBEPP86 : SimpleKeyword
-        DFT functional
-    WPR2SCAN50 : SimpleKeyword
-        DFT functional
-    WR2SCAN : SimpleKeyword
-        DFT functional
-    X3LYP : SimpleKeyword
-        DFT functional
-    XHF : SimpleKeyword
-        DFT functional
-    XLYP : SimpleKeyword
-        DFT functional
-    """
+    """Enum to store all simple keywords of type Dft."""
 
     B3LYP3C = SimpleKeyword("b3lyp3c")
+    """SimpleKeyword: DFT 3c methods, does not require dispersion correction or basis set separately."""
     B973C = SimpleKeyword("b973c")
+    """SimpleKeyword: DFT 3c methods, does not require dispersion correction or basis set separately."""
     PBEH3C = SimpleKeyword("pbeh3c")
+    """SimpleKeyword: DFT 3c methods, does not require dispersion correction or basis set separately."""
     WB97X3C = SimpleKeyword("wb97x3c")
+    """SimpleKeyword: DFT 3c methods, does not require dispersion correction or basis set separately."""
     B3LYP_GCP_D3_6_31G_D = SimpleKeyword("b3lyp-gcp-d3/6-31g(d)")
+    """SimpleKeyword: Dft."""
     B3LYP_GCP_D3_6_31GSTAR = SimpleKeyword("b3lyp-gcp-d3/6-31g*")
+    """SimpleKeyword: DFT - similar to 3c methods, does not require dispersion correction or basis set separately."""
     FOD = SimpleKeyword("fod")
+    """SimpleKeyword: DFT with smearing for determining multireference character (TPSS/def2-TZVP, T = 5000 K)."""
     B1LYP = SimpleKeyword("b1lyp")
+    """SimpleKeyword: DFT functional."""
     B1P = SimpleKeyword("b1p")
+    """SimpleKeyword: DFT functional."""
     B1P86 = SimpleKeyword("b1p86")
+    """SimpleKeyword: DFT functional."""
     B1PBE = SimpleKeyword("b1pbe")
+    """SimpleKeyword: DFT functional."""
     B1PW = SimpleKeyword("b1pw")
+    """SimpleKeyword: DFT functional."""
     B1PW91 = SimpleKeyword("b1pw91")
+    """SimpleKeyword: DFT functional."""
     B2GP_PLYP = SimpleKeyword("b2gp-plyp")
+    """SimpleKeyword: DFT functional."""
     B2K_PLYP = SimpleKeyword("b2k-plyp")
+    """SimpleKeyword: DFT functional."""
     B2PLYP = SimpleKeyword("b2plyp")
+    """SimpleKeyword: DFT functional."""
     B2T_PLYP = SimpleKeyword("b2t-plyp")
+    """SimpleKeyword: DFT functional."""
     B3LYP = SimpleKeyword("b3lyp")
+    """SimpleKeyword: DFT functional."""
     B3LYP_G = SimpleKeyword("b3lyp_g")
+    """SimpleKeyword: DFT functional."""
     B3P = SimpleKeyword("b3p")
+    """SimpleKeyword: DFT functional."""
     B3P86 = SimpleKeyword("b3p86")
+    """SimpleKeyword: DFT functional."""
     B3PBE = SimpleKeyword("b3pbe")
+    """SimpleKeyword: DFT functional."""
     B3PW = SimpleKeyword("b3pw")
+    """SimpleKeyword: DFT functional."""
     B3PW91 = SimpleKeyword("b3pw91")
+    """SimpleKeyword: DFT functional."""
     B97 = SimpleKeyword("b97")
+    """SimpleKeyword: DFT functional."""
     B97_D = SimpleKeyword("b97-d")
+    """SimpleKeyword: DFT functional."""
     B97_D3 = SimpleKeyword("b97-d3")
+    """SimpleKeyword: DFT functional."""
     B97_D4 = SimpleKeyword("b97-d4")
+    """SimpleKeyword: DFT functional."""
     B97M_D3BJ = SimpleKeyword("b97m-d3bj")
+    """SimpleKeyword: DFT functional."""
     B97M_D4 = SimpleKeyword("b97m-d4")
+    """SimpleKeyword: DFT functional."""
     B97M_V = SimpleKeyword("b97m-v")
+    """SimpleKeyword: DFT functional."""
     BHANDHLYP = SimpleKeyword("bhandhlyp")
+    """SimpleKeyword: DFT functional."""
     BHLYP = SimpleKeyword("bhlyp")
+    """SimpleKeyword: DFT functional."""
     BLYP = SimpleKeyword("blyp")
+    """SimpleKeyword: DFT functional."""
     BNULL = SimpleKeyword("bnull")
+    """SimpleKeyword: DFT functional."""
     BP86 = SimpleKeyword("bp86")
+    """SimpleKeyword: DFT functional."""
     BPBE = SimpleKeyword("bpbe")
+    """SimpleKeyword: DFT functional."""
     BPW = SimpleKeyword("bpw")
+    """SimpleKeyword: DFT functional."""
     BPW91 = SimpleKeyword("bpw91")
+    """SimpleKeyword: DFT functional."""
     BVWN = SimpleKeyword("bvwn")
+    """SimpleKeyword: DFT functional."""
     CAM_B3LYP = SimpleKeyword("cam-b3lyp")
+    """SimpleKeyword: DFT functional."""
     DLPNO_B2GP_PLYP = SimpleKeyword("dlpno-b2gp-plyp")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_B2K_PLYP = SimpleKeyword("dlpno-b2k-plyp")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_B2PLYP = SimpleKeyword("dlpno-b2plyp")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_B2T_PLYP = SimpleKeyword("dlpno-b2t-plyp")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_DSD_BLYP = SimpleKeyword("dlpno-dsd-blyp")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_DSD_PBEB95 = SimpleKeyword("dlpno-dsd-pbeb95")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_DSD_PBEP86 = SimpleKeyword("dlpno-dsd-pbep86")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_KPR2SCAN50 = SimpleKeyword("dlpno-kpr2scan50")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_MPW2PLYP = SimpleKeyword("dlpno-mpw2plyp")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_PBE_QIDH = SimpleKeyword("dlpno-pbe-qidh")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_PBE0_2 = SimpleKeyword("dlpno-pbe0-2")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_PBE0_DH = SimpleKeyword("dlpno-pbe0-dh")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_PR2SCAN50 = SimpleKeyword("dlpno-pr2scan50")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_PR2SCAN69 = SimpleKeyword("dlpno-pr2scan69")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_PWPB95 = SimpleKeyword("dlpno-pwpb95")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_R2SCAN_CIDH = SimpleKeyword("dlpno-r2scan-cidh")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_R2SCAN_QIDH = SimpleKeyword("dlpno-r2scan-qidh")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_R2SCAN0_2 = SimpleKeyword("dlpno-r2scan0-2")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_R2SCAN0_DH = SimpleKeyword("dlpno-r2scan0-dh")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_RSX_0DH = SimpleKeyword("dlpno-rsx-0dh")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_RSX_QIDH = SimpleKeyword("dlpno-rsx-qidh")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SCS_B2GP_PLYP21 = SimpleKeyword("dlpno-scs-b2gp-plyp21")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SCS_PBE_QIDH = SimpleKeyword("dlpno-scs-pbe-qidh")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SCS_RSX_QIDH = SimpleKeyword("dlpno-scs-rsx-qidh")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SCS_WB2GP_PLYP = SimpleKeyword("dlpno-scs-wb2gp-plyp")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SCS_WB88PP86 = SimpleKeyword("dlpno-scs-wb88pp86")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SCS_WPBEPP86 = SimpleKeyword("dlpno-scs-wpbepp86")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SCS_SOS_B2PLYP21 = SimpleKeyword("dlpno-scs/sos-b2plyp21")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SCS_SOS_WB2PLYP = SimpleKeyword("dlpno-scs/sos-wb2plyp")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SOS_B2GP_PLYP21 = SimpleKeyword("dlpno-sos-b2gp-plyp21")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SOS_PBE_QIDH = SimpleKeyword("dlpno-sos-pbe-qidh")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SOS_RSX_QIDH = SimpleKeyword("dlpno-sos-rsx-qidh")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SOS_WB2GP_PLYP = SimpleKeyword("dlpno-sos-wb2gp-plyp")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SOS_WB88PP86 = SimpleKeyword("dlpno-sos-wb88pp86")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_SOS_WPBEPP86 = SimpleKeyword("dlpno-sos-wpbepp86")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_WB2GP_PLYP = SimpleKeyword("dlpno-wb2gp-plyp")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_WB2PLYP = SimpleKeyword("dlpno-wb2plyp")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_WB88PP86 = SimpleKeyword("dlpno-wb88pp86")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_WB97M_2 = SimpleKeyword("dlpno-wb97m(2)")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_WB97X_2 = SimpleKeyword("dlpno-wb97x-2")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_WB97X_2_TQZ = SimpleKeyword(
         "dlpno-wb97x-2(tqz)"
     )  # Double-hybrid DFT with DLPNO approximation
     DLPNO_WPBEPP86 = SimpleKeyword("dlpno-wpbepp86")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_WPR2SCAN50 = SimpleKeyword("dlpno-wpr2scan50")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DSD_BLYP = SimpleKeyword("dsd-blyp")
+    """SimpleKeyword: DFT functional."""
     DSD_PBEB95 = SimpleKeyword("dsd-pbeb95")
+    """SimpleKeyword: DFT functional."""
     DSD_PBEP86 = SimpleKeyword("dsd-pbep86")
+    """SimpleKeyword: DFT functional."""
     G1LYP = SimpleKeyword("g1lyp")
+    """SimpleKeyword: DFT functional."""
     G1P = SimpleKeyword("g1p")
+    """SimpleKeyword: DFT functional."""
     G3LYP = SimpleKeyword("g3lyp")
+    """SimpleKeyword: DFT functional."""
     G3P = SimpleKeyword("g3p")
+    """SimpleKeyword: DFT functional."""
     GLYP = SimpleKeyword("glyp")
+    """SimpleKeyword: DFT functional."""
     GP = SimpleKeyword("gp")
+    """SimpleKeyword: DFT functional."""
     HFLDA = SimpleKeyword("hflda")
+    """SimpleKeyword: DFT functional."""
     HFS = SimpleKeyword("hfs")
+    """SimpleKeyword: DFT functional."""
     KPR2SCAN50 = SimpleKeyword("kpr2scan50")
+    """SimpleKeyword: DFT functional."""
     LB94 = SimpleKeyword("lb94")
+    """SimpleKeyword: DFT functional."""
     LC_BLYP = SimpleKeyword("lc-blyp")
+    """SimpleKeyword: DFT functional."""
     LC_PBE = SimpleKeyword("lc-pbe")
+    """SimpleKeyword: DFT functional."""
     LDA = SimpleKeyword("lda")
+    """SimpleKeyword: DFT functional."""
     LRC_PBE = SimpleKeyword("lrc-pbe")
+    """SimpleKeyword: DFT functional."""
     LSD = SimpleKeyword("lsd")
+    """SimpleKeyword: DFT functional."""
     M06 = SimpleKeyword("m06")
+    """SimpleKeyword: DFT functional."""
     M062X = SimpleKeyword("m062x")
+    """SimpleKeyword: DFT functional."""
     M06L = SimpleKeyword("m06l")
+    """SimpleKeyword: DFT functional."""
     MPW1LYP = SimpleKeyword("mpw1lyp")
+    """SimpleKeyword: DFT functional."""
     MPW1PW = SimpleKeyword("mpw1pw")
+    """SimpleKeyword: DFT functional."""
     MPW2PLYP = SimpleKeyword("mpw2plyp")
+    """SimpleKeyword: DFT functional."""
     MPWLYP = SimpleKeyword("mpwlyp")
+    """SimpleKeyword: DFT functional."""
     MPWPW = SimpleKeyword("mpwpw")
+    """SimpleKeyword: DFT functional."""
     O3LYP = SimpleKeyword("o3lyp")
+    """SimpleKeyword: DFT functional."""
     OLYP = SimpleKeyword("olyp")
+    """SimpleKeyword: DFT functional."""
     OPBE = SimpleKeyword("opbe")
+    """SimpleKeyword: DFT functional."""
     PBE = SimpleKeyword("pbe")
+    """SimpleKeyword: DFT functional."""
     PBE_QIDH = SimpleKeyword("pbe-qidh")
+    """SimpleKeyword: DFT functional."""
     PBE0 = SimpleKeyword("pbe0")
+    """SimpleKeyword: DFT functional."""
     PBE0_2 = SimpleKeyword("pbe0-2")
+    """SimpleKeyword: DFT functional."""
     PBE0_DH = SimpleKeyword("pbe0-dh")
+    """SimpleKeyword: DFT functional."""
     PR2SCAN50 = SimpleKeyword("pr2scan50")
+    """SimpleKeyword: DFT functional."""
     PR2SCAN69 = SimpleKeyword("pr2scan69")
+    """SimpleKeyword: DFT functional."""
     PW1PW = SimpleKeyword("pw1pw")
+    """SimpleKeyword: DFT functional."""
     PW6B95 = SimpleKeyword("pw6b95")
+    """SimpleKeyword: DFT functional."""
     PW86PBE = SimpleKeyword("pw86pbe")
+    """SimpleKeyword: DFT functional."""
     PW91 = SimpleKeyword("pw91")
+    """SimpleKeyword: DFT functional."""
     PW91_0 = SimpleKeyword("pw91_0")
+    """SimpleKeyword: DFT functional."""
     PWLDA = SimpleKeyword("pwlda")
+    """SimpleKeyword: DFT functional."""
     PWP = SimpleKeyword("pwp")
+    """SimpleKeyword: DFT functional."""
     PWP1 = SimpleKeyword("pwp1")
+    """SimpleKeyword: DFT functional."""
     PWPB95 = SimpleKeyword("pwpb95")
+    """SimpleKeyword: DFT functional."""
     R2SCAN = SimpleKeyword("r2scan")
+    """SimpleKeyword: DFT functional."""
     R2SCAN_3C = SimpleKeyword("r2scan-3c")
+    """SimpleKeyword: DFT functional."""
     R2SCAN_CIDH = SimpleKeyword("r2scan-cidh")
+    """SimpleKeyword: DFT functional."""
     R2SCAN_QIDH = SimpleKeyword("r2scan-qidh")
+    """SimpleKeyword: DFT functional."""
     R2SCAN0 = SimpleKeyword("r2scan0")
+    """SimpleKeyword: DFT functional."""
     R2SCAN0 = SimpleKeyword("r2scan0")
+    """SimpleKeyword: DFT functional."""
     R2SCAN0_2 = SimpleKeyword("r2scan0-2")
+    """SimpleKeyword: DFT functional."""
     R2SCAN0_DH = SimpleKeyword("r2scan0-dh")
+    """SimpleKeyword: DFT functional."""
     R2SCAN50 = SimpleKeyword("r2scan50")
+    """SimpleKeyword: DFT functional."""
     R2SCANH = SimpleKeyword("r2scanh")
+    """SimpleKeyword: DFT functional."""
     REVDOD_PBEP86_D4_2021 = SimpleKeyword("revdod-pbep86-d4/2021")
+    """SimpleKeyword: DFT functional."""
     REVDOD_PBEP86_2021 = SimpleKeyword("revdod-pbep86/2021")
+    """SimpleKeyword: DFT functional."""
     REVDSD_PBEP86_D4_2021 = SimpleKeyword("revdsd-pbep86-d4/2021")
+    """SimpleKeyword: DFT functional."""
     REVDSD_PBEP86_2021 = SimpleKeyword("revdsd-pbep86/2021")
+    """SimpleKeyword: DFT functional."""
     REVPBE = SimpleKeyword("revpbe")
+    """SimpleKeyword: DFT functional."""
     REVPBE0 = SimpleKeyword("revpbe0")
+    """SimpleKeyword: DFT functional."""
     REVPBE38 = SimpleKeyword("revpbe38")
+    """SimpleKeyword: DFT functional."""
     REVTPSS = SimpleKeyword("revtpss")
+    """SimpleKeyword: DFT functional."""
     RPBE = SimpleKeyword("rpbe")
+    """SimpleKeyword: DFT functional."""
     RPW86PBE = SimpleKeyword("rpw86pbe")
+    """SimpleKeyword: DFT functional."""
     RSCAN = SimpleKeyword("rscan")
+    """SimpleKeyword: DFT functional."""
     RSX_0DH = SimpleKeyword("rsx-0dh")
+    """SimpleKeyword: DFT functional."""
     RSX_QIDH = SimpleKeyword("rsx-qidh")
+    """SimpleKeyword: DFT functional."""
     SCANFUNC = SimpleKeyword("scanfunc")
+    """SimpleKeyword: DFT functional."""
     SCS_B2GP_PLYP21 = SimpleKeyword("scs-b2gp-plyp21")
+    """SimpleKeyword: DFT functional."""
     SCS_PBE_QIDH = SimpleKeyword("scs-pbe-qidh")
+    """SimpleKeyword: DFT functional."""
     SCS_RSX_QIDH = SimpleKeyword("scs-rsx-qidh")
+    """SimpleKeyword: DFT functional."""
     SCS_WB2GP_PLYP = SimpleKeyword("scs-wb2gp-plyp")
+    """SimpleKeyword: DFT functional."""
     SCS_WB88PP86 = SimpleKeyword("scs-wb88pp86")
+    """SimpleKeyword: DFT functional."""
     SCS_WPBEPP86 = SimpleKeyword("scs-wpbepp86")
+    """SimpleKeyword: DFT functional."""
     SCS_SOS_B2PLYP21 = SimpleKeyword("scs/sos-b2plyp21")
+    """SimpleKeyword: DFT functional."""
     SCS_SOS_WB2PLYP = SimpleKeyword("scs/sos-wb2plyp")
+    """SimpleKeyword: DFT functional."""
     SOS_B2GP_PLYP21 = SimpleKeyword("sos-b2gp-plyp21")
+    """SimpleKeyword: DFT functional."""
     SOS_PBE_QIDH = SimpleKeyword("sos-pbe-qidh")
+    """SimpleKeyword: DFT functional."""
     SOS_RSX_QIDH = SimpleKeyword("sos-rsx-qidh")
+    """SimpleKeyword: DFT functional."""
     SOS_WB2GP_PLYP = SimpleKeyword("sos-wb2gp-plyp")
+    """SimpleKeyword: DFT functional."""
     SOS_WB88PP86 = SimpleKeyword("sos-wb88pp86")
+    """SimpleKeyword: DFT functional."""
     SOS_WPBEPP86 = SimpleKeyword("sos-wpbepp86")
+    """SimpleKeyword: DFT functional."""
     TPSS = SimpleKeyword("tpss")
+    """SimpleKeyword: DFT functional."""
     TPSS0 = SimpleKeyword("tpss0")
+    """SimpleKeyword: DFT functional."""
     TPSSH = SimpleKeyword("tpssh")
+    """SimpleKeyword: DFT functional."""
     VWN = SimpleKeyword("vwn")
+    """SimpleKeyword: DFT functional."""
     VWN3 = SimpleKeyword("vwn3")
+    """SimpleKeyword: DFT functional."""
     VWN5 = SimpleKeyword("vwn5")
+    """SimpleKeyword: DFT functional."""
     WB2GP_PLYP = SimpleKeyword("wb2gp-plyp")
+    """SimpleKeyword: DFT functional."""
     WB2PLYP = SimpleKeyword("wb2plyp")
+    """SimpleKeyword: DFT functional."""
     WB88PP86 = SimpleKeyword("wb88pp86")
+    """SimpleKeyword: DFT functional."""
     WB97 = SimpleKeyword("wb97")
+    """SimpleKeyword: DFT functional."""
     WB97M_D3BJ = SimpleKeyword("wb97m-d3bj")
+    """SimpleKeyword: DFT functional."""
     WB97M_D4 = SimpleKeyword("wb97m-d4")
+    """SimpleKeyword: DFT functional."""
     WB97M_D4REV = SimpleKeyword("wb97m-d4rev")
+    """SimpleKeyword: DFT functional."""
     WB97M_V = SimpleKeyword("wb97m-v")
+    """SimpleKeyword: DFT functional."""
     WB97M_2 = SimpleKeyword("wb97m(2)")
+    """SimpleKeyword: DFT functional."""
     WB97X = SimpleKeyword("wb97x")
+    """SimpleKeyword: DFT functional."""
     WB97X_2 = SimpleKeyword("wb97x-2")
+    """SimpleKeyword: DFT functional."""
     WB97X_2_TQZ = SimpleKeyword("wb97x-2(tqz)")
+    """SimpleKeyword: DFT functional."""
     WB97X_D3 = SimpleKeyword("wb97x-d3")
+    """SimpleKeyword: DFT functional."""
     WB97X_D3BJ = SimpleKeyword("wb97x-d3bj")
+    """SimpleKeyword: DFT functional."""
     WB97X_D4 = SimpleKeyword("wb97x-d4")
+    """SimpleKeyword: DFT functional."""
     WB97X_D4REV = SimpleKeyword("wb97x-d4rev")
+    """SimpleKeyword: DFT functional."""
     WB97X_V = SimpleKeyword("wb97x-v")
+    """SimpleKeyword: DFT functional."""
     WPBEPP86 = SimpleKeyword("wpbepp86")
+    """SimpleKeyword: DFT functional."""
     WPR2SCAN50 = SimpleKeyword("wpr2scan50")
+    """SimpleKeyword: DFT functional."""
     WR2SCAN = SimpleKeyword("wr2scan")
+    """SimpleKeyword: DFT functional."""
     X3LYP = SimpleKeyword("x3lyp")
+    """SimpleKeyword: DFT functional."""
     XHF = SimpleKeyword("xhf")
+    """SimpleKeyword: DFT functional."""
     XLYP = SimpleKeyword("xlyp")
+    """SimpleKeyword: DFT functional."""

--- a/src/opi/input/simple_keywords/dft.py
+++ b/src/opi/input/simple_keywords/dft.py
@@ -171,9 +171,8 @@ class Dft(SimpleKeywordBox):
     """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_WB97X_2 = SimpleKeyword("dlpno-wb97x-2")
     """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
-    DLPNO_WB97X_2_TQZ = SimpleKeyword(
-        "dlpno-wb97x-2(tqz)"
-    )  # Double-hybrid DFT with DLPNO approximation
+    DLPNO_WB97X_2_TQZ = SimpleKeyword("dlpno-wb97x-2(tqz)")
+    """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_WPBEPP86 = SimpleKeyword("dlpno-wpbepp86")
     """SimpleKeyword: Double-hybrid DFT with DLPNO approximation."""
     DLPNO_WPR2SCAN50 = SimpleKeyword("dlpno-wpr2scan50")

--- a/src/opi/input/simple_keywords/dft.py
+++ b/src/opi/input/simple_keywords/dft.py
@@ -7,261 +7,601 @@ __all__ = ("Dft",)
 
 
 class Dft(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Dft"""
+    """Enum to store all simple keywords of type Dft.
 
-    B3LYP3C = SimpleKeyword(
-        "b3lyp3c"
-    )  # DFT 3c methods, do not require dispersion correction or basis set
-    B973C = SimpleKeyword(
-        "b973c"
-    )  # DFT 3c methods, do not require dispersion correction or basis set
-    PBEH3C = SimpleKeyword(
-        "pbeh3c"
-    )  # DFT 3c methods, do not require dispersion correction or basis set
-    WB97X3C = SimpleKeyword(
-        "wb97x3c"
-    )  # DFT 3c methods, do not require dispersion correction or basis set
+    Attributes
+    ----------
+    B3LYP3C : SimpleKeyword
+        DFT 3c methods, do not require dispersion correction or basis set
+    B973C : SimpleKeyword
+        DFT 3c methods, do not require dispersion correction or basis set
+    PBEH3C : SimpleKeyword
+        DFT 3c methods, do not require dispersion correction or basis set
+    WB97X3C : SimpleKeyword
+        DFT 3c methods, do not require dispersion correction or basis set
+    B3LYP_GCP_D3_6_31G_D : SimpleKeyword
+        Dft
+    B3LYP_GCP_D3_6_31GSTAR : SimpleKeyword
+        DFT like 3c methods, do not require dispersion correction or basis set
+    FOD : SimpleKeyword
+        DFT with smearing for determining multireference character (TPSS/def2-TZVP, T = 5000 K)
+    B1LYP : SimpleKeyword
+        DFT functional
+    B1P : SimpleKeyword
+        DFT functional
+    B1P86 : SimpleKeyword
+        DFT functional
+    B1PBE : SimpleKeyword
+        DFT functional
+    B1PW : SimpleKeyword
+        DFT functional
+    B1PW91 : SimpleKeyword
+        DFT functional
+    B2GP_PLYP : SimpleKeyword
+        DFT functional
+    B2K_PLYP : SimpleKeyword
+        DFT functional
+    B2PLYP : SimpleKeyword
+        DFT functional
+    B2T_PLYP : SimpleKeyword
+        DFT functional
+    B3LYP : SimpleKeyword
+        DFT functional
+    B3LYP_G : SimpleKeyword
+        DFT functional
+    B3P : SimpleKeyword
+        DFT functional
+    B3P86 : SimpleKeyword
+        DFT functional
+    B3PBE : SimpleKeyword
+        DFT functional
+    B3PW : SimpleKeyword
+        DFT functional
+    B3PW91 : SimpleKeyword
+        DFT functional
+    B97 : SimpleKeyword
+        DFT functional
+    B97_D : SimpleKeyword
+        DFT functional
+    B97_D3 : SimpleKeyword
+        DFT functional
+    B97_D4 : SimpleKeyword
+        DFT functional
+    B97M_D3BJ : SimpleKeyword
+        DFT functional
+    B97M_D4 : SimpleKeyword
+        DFT functional
+    B97M_V : SimpleKeyword
+        DFT functional
+    BHANDHLYP : SimpleKeyword
+        DFT functional
+    BHLYP : SimpleKeyword
+        DFT functional
+    BLYP : SimpleKeyword
+        DFT functional
+    BNULL : SimpleKeyword
+        DFT functional
+    BP86 : SimpleKeyword
+        DFT functional
+    BPBE : SimpleKeyword
+        DFT functional
+    BPW : SimpleKeyword
+        DFT functional
+    BPW91 : SimpleKeyword
+        DFT functional
+    BVWN : SimpleKeyword
+        DFT functional
+    CAM_B3LYP : SimpleKeyword
+        DFT functional
+    DLPNO_B2GP_PLYP : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_B2K_PLYP : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_B2PLYP : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_B2T_PLYP : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_DSD_BLYP : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_DSD_PBEB95 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_DSD_PBEP86 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_KPR2SCAN50 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_MPW2PLYP : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_PBE_QIDH : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_PBE0_2 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_PBE0_DH : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_PR2SCAN50 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_PR2SCAN69 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_PWPB95 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_R2SCAN_CIDH : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_R2SCAN_QIDH : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_R2SCAN0_2 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_R2SCAN0_DH : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_RSX_0DH : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_RSX_QIDH : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SCS_B2GP_PLYP21 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SCS_PBE_QIDH : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SCS_RSX_QIDH : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SCS_WB2GP_PLYP : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SCS_WB88PP86 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SCS_WPBEPP86 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SCS_SOS_B2PLYP21 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SCS_SOS_WB2PLYP : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SOS_B2GP_PLYP21 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SOS_PBE_QIDH : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SOS_RSX_QIDH : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SOS_WB2GP_PLYP : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SOS_WB88PP86 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_SOS_WPBEPP86 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_WB2GP_PLYP : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_WB2PLYP : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_WB88PP86 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_WB97M_2 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_WB97X_2 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_WB97X_2_TQZ : SimpleKeyword
+        Dft
+    DLPNO_WPBEPP86 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DLPNO_WPR2SCAN50 : SimpleKeyword
+        Double-hybrid DFT with DLPNO approximation
+    DSD_BLYP : SimpleKeyword
+        DFT functional
+    DSD_PBEB95 : SimpleKeyword
+        DFT functional
+    DSD_PBEP86 : SimpleKeyword
+        DFT functional
+    G1LYP : SimpleKeyword
+        DFT functional
+    G1P : SimpleKeyword
+        DFT functional
+    G3LYP : SimpleKeyword
+        DFT functional
+    G3P : SimpleKeyword
+        DFT functional
+    GLYP : SimpleKeyword
+        DFT functional
+    GP : SimpleKeyword
+        DFT functional
+    HFLDA : SimpleKeyword
+        DFT functional
+    HFS : SimpleKeyword
+        DFT functional
+    KPR2SCAN50 : SimpleKeyword
+        DFT functional
+    LB94 : SimpleKeyword
+        DFT functional
+    LC_BLYP : SimpleKeyword
+        DFT functional
+    LC_PBE : SimpleKeyword
+        DFT functional
+    LDA : SimpleKeyword
+        DFT functional
+    LRC_PBE : SimpleKeyword
+        DFT functional
+    LSD : SimpleKeyword
+        DFT functional
+    M06 : SimpleKeyword
+        DFT functional
+    M062X : SimpleKeyword
+        DFT functional
+    M06L : SimpleKeyword
+        DFT functional
+    MPW1LYP : SimpleKeyword
+        DFT functional
+    MPW1PW : SimpleKeyword
+        DFT functional
+    MPW2PLYP : SimpleKeyword
+        DFT functional
+    MPWLYP : SimpleKeyword
+        DFT functional
+    MPWPW : SimpleKeyword
+        DFT functional
+    O3LYP : SimpleKeyword
+        DFT functional
+    OLYP : SimpleKeyword
+        DFT functional
+    OPBE : SimpleKeyword
+        DFT functional
+    PBE : SimpleKeyword
+        DFT functional
+    PBE_QIDH : SimpleKeyword
+        DFT functional
+    PBE0 : SimpleKeyword
+        DFT functional
+    PBE0_2 : SimpleKeyword
+        DFT functional
+    PBE0_DH : SimpleKeyword
+        DFT functional
+    PR2SCAN50 : SimpleKeyword
+        DFT functional
+    PR2SCAN69 : SimpleKeyword
+        DFT functional
+    PW1PW : SimpleKeyword
+        DFT functional
+    PW6B95 : SimpleKeyword
+        DFT functional
+    PW86PBE : SimpleKeyword
+        DFT functional
+    PW91 : SimpleKeyword
+        DFT functional
+    PW91_0 : SimpleKeyword
+        DFT functional
+    PWLDA : SimpleKeyword
+        DFT functional
+    PWP : SimpleKeyword
+        DFT functional
+    PWP1 : SimpleKeyword
+        DFT functional
+    PWPB95 : SimpleKeyword
+        DFT functional
+    R2SCAN : SimpleKeyword
+        DFT functional
+    R2SCAN_3C : SimpleKeyword
+        DFT functional
+    R2SCAN_CIDH : SimpleKeyword
+        DFT functional
+    R2SCAN_QIDH : SimpleKeyword
+        DFT functional
+    R2SCAN0 : SimpleKeyword
+        DFT functional
+    R2SCAN0 : SimpleKeyword
+        DFT functional
+    R2SCAN0_2 : SimpleKeyword
+        DFT functional
+    R2SCAN0_DH : SimpleKeyword
+        DFT functional
+    R2SCAN50 : SimpleKeyword
+        DFT functional
+    R2SCANH : SimpleKeyword
+        DFT functional
+    REVDOD_PBEP86_D4_2021 : SimpleKeyword
+        DFT functional
+    REVDOD_PBEP86_2021 : SimpleKeyword
+        DFT functional
+    REVDSD_PBEP86_D4_2021 : SimpleKeyword
+        DFT functional
+    REVDSD_PBEP86_2021 : SimpleKeyword
+        DFT functional
+    REVPBE : SimpleKeyword
+        DFT functional
+    REVPBE0 : SimpleKeyword
+        DFT functional
+    REVPBE38 : SimpleKeyword
+        DFT functional
+    REVTPSS : SimpleKeyword
+        DFT functional
+    RPBE : SimpleKeyword
+        DFT functional
+    RPW86PBE : SimpleKeyword
+        DFT functional
+    RSCAN : SimpleKeyword
+        DFT functional
+    RSX_0DH : SimpleKeyword
+        DFT functional
+    RSX_QIDH : SimpleKeyword
+        DFT functional
+    SCANFUNC : SimpleKeyword
+        DFT functional
+    SCS_B2GP_PLYP21 : SimpleKeyword
+        DFT functional
+    SCS_PBE_QIDH : SimpleKeyword
+        DFT functional
+    SCS_RSX_QIDH : SimpleKeyword
+        DFT functional
+    SCS_WB2GP_PLYP : SimpleKeyword
+        DFT functional
+    SCS_WB88PP86 : SimpleKeyword
+        DFT functional
+    SCS_WPBEPP86 : SimpleKeyword
+        DFT functional
+    SCS_SOS_B2PLYP21 : SimpleKeyword
+        DFT functional
+    SCS_SOS_WB2PLYP : SimpleKeyword
+        DFT functional
+    SOS_B2GP_PLYP21 : SimpleKeyword
+        DFT functional
+    SOS_PBE_QIDH : SimpleKeyword
+        DFT functional
+    SOS_RSX_QIDH : SimpleKeyword
+        DFT functional
+    SOS_WB2GP_PLYP : SimpleKeyword
+        DFT functional
+    SOS_WB88PP86 : SimpleKeyword
+        DFT functional
+    SOS_WPBEPP86 : SimpleKeyword
+        DFT functional
+    TPSS : SimpleKeyword
+        DFT functional
+    TPSS0 : SimpleKeyword
+        DFT functional
+    TPSSH : SimpleKeyword
+        DFT functional
+    VWN : SimpleKeyword
+        DFT functional
+    VWN3 : SimpleKeyword
+        DFT functional
+    VWN5 : SimpleKeyword
+        DFT functional
+    WB2GP_PLYP : SimpleKeyword
+        DFT functional
+    WB2PLYP : SimpleKeyword
+        DFT functional
+    WB88PP86 : SimpleKeyword
+        DFT functional
+    WB97 : SimpleKeyword
+        DFT functional
+    WB97M_D3BJ : SimpleKeyword
+        DFT functional
+    WB97M_D4 : SimpleKeyword
+        DFT functional
+    WB97M_D4REV : SimpleKeyword
+        DFT functional
+    WB97M_V : SimpleKeyword
+        DFT functional
+    WB97M_2 : SimpleKeyword
+        DFT functional
+    WB97X : SimpleKeyword
+        DFT functional
+    WB97X_2 : SimpleKeyword
+        DFT functional
+    WB97X_2_TQZ : SimpleKeyword
+        DFT functional
+    WB97X_D3 : SimpleKeyword
+        DFT functional
+    WB97X_D3BJ : SimpleKeyword
+        DFT functional
+    WB97X_D4 : SimpleKeyword
+        DFT functional
+    WB97X_D4REV : SimpleKeyword
+        DFT functional
+    WB97X_V : SimpleKeyword
+        DFT functional
+    WPBEPP86 : SimpleKeyword
+        DFT functional
+    WPR2SCAN50 : SimpleKeyword
+        DFT functional
+    WR2SCAN : SimpleKeyword
+        DFT functional
+    X3LYP : SimpleKeyword
+        DFT functional
+    XHF : SimpleKeyword
+        DFT functional
+    XLYP : SimpleKeyword
+        DFT functional
+    """
+
+    B3LYP3C = SimpleKeyword("b3lyp3c")
+    B973C = SimpleKeyword("b973c")
+    PBEH3C = SimpleKeyword("pbeh3c")
+    WB97X3C = SimpleKeyword("wb97x3c")
     B3LYP_GCP_D3_6_31G_D = SimpleKeyword(
         "b3lyp-gcp-d3/6-31g(d)"
     )  # DFT like 3c methods, do not require dispersion correction or basis set
-    B3LYP_GCP_D3_6_31GSTAR = SimpleKeyword(
-        "b3lyp-gcp-d3/6-31g*"
-    )  # DFT like 3c methods, do not require dispersion correction or basis set
-    FOD = SimpleKeyword(
-        "fod"
-    )  # DFT with smearing for determining multireference character (TPSS/def2-TZVP, T = 5000 K)
-    B1LYP = SimpleKeyword("b1lyp")  # DFT functional
-    B1P = SimpleKeyword("b1p")  # DFT functional
-    B1P86 = SimpleKeyword("b1p86")  # DFT functional
-    B1PBE = SimpleKeyword("b1pbe")  # DFT functional
-    B1PW = SimpleKeyword("b1pw")  # DFT functional
-    B1PW91 = SimpleKeyword("b1pw91")  # DFT functional
-    B2GP_PLYP = SimpleKeyword("b2gp-plyp")  # DFT functional
-    B2K_PLYP = SimpleKeyword("b2k-plyp")  # DFT functional
-    B2PLYP = SimpleKeyword("b2plyp")  # DFT functional
-    B2T_PLYP = SimpleKeyword("b2t-plyp")  # DFT functional
-    B3LYP = SimpleKeyword("b3lyp")  # DFT functional
-    B3LYP_G = SimpleKeyword("b3lyp_g")  # DFT functional
-    B3P = SimpleKeyword("b3p")  # DFT functional
-    B3P86 = SimpleKeyword("b3p86")  # DFT functional
-    B3PBE = SimpleKeyword("b3pbe")  # DFT functional
-    B3PW = SimpleKeyword("b3pw")  # DFT functional
-    B3PW91 = SimpleKeyword("b3pw91")  # DFT functional
-    B97 = SimpleKeyword("b97")  # DFT functional
-    B97_D = SimpleKeyword("b97-d")  # DFT functional
-    B97_D3 = SimpleKeyword("b97-d3")  # DFT functional
-    B97_D4 = SimpleKeyword("b97-d4")  # DFT functional
-    B97M_D3BJ = SimpleKeyword("b97m-d3bj")  # DFT functional
-    B97M_D4 = SimpleKeyword("b97m-d4")  # DFT functional
-    B97M_V = SimpleKeyword("b97m-v")  # DFT functional
-    BHANDHLYP = SimpleKeyword("bhandhlyp")  # DFT functional
-    BHLYP = SimpleKeyword("bhlyp")  # DFT functional
-    BLYP = SimpleKeyword("blyp")  # DFT functional
-    BNULL = SimpleKeyword("bnull")  # DFT functional
-    BP86 = SimpleKeyword("bp86")  # DFT functional
-    BPBE = SimpleKeyword("bpbe")  # DFT functional
-    BPW = SimpleKeyword("bpw")  # DFT functional
-    BPW91 = SimpleKeyword("bpw91")  # DFT functional
-    BVWN = SimpleKeyword("bvwn")  # DFT functional
-    CAM_B3LYP = SimpleKeyword("cam-b3lyp")  # DFT functional
-    DLPNO_B2GP_PLYP = SimpleKeyword("dlpno-b2gp-plyp")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_B2K_PLYP = SimpleKeyword("dlpno-b2k-plyp")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_B2PLYP = SimpleKeyword("dlpno-b2plyp")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_B2T_PLYP = SimpleKeyword("dlpno-b2t-plyp")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_DSD_BLYP = SimpleKeyword("dlpno-dsd-blyp")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_DSD_PBEB95 = SimpleKeyword(
-        "dlpno-dsd-pbeb95"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_DSD_PBEP86 = SimpleKeyword(
-        "dlpno-dsd-pbep86"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_KPR2SCAN50 = SimpleKeyword(
-        "dlpno-kpr2scan50"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_MPW2PLYP = SimpleKeyword("dlpno-mpw2plyp")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_PBE_QIDH = SimpleKeyword("dlpno-pbe-qidh")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_PBE0_2 = SimpleKeyword("dlpno-pbe0-2")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_PBE0_DH = SimpleKeyword("dlpno-pbe0-dh")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_PR2SCAN50 = SimpleKeyword("dlpno-pr2scan50")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_PR2SCAN69 = SimpleKeyword("dlpno-pr2scan69")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_PWPB95 = SimpleKeyword("dlpno-pwpb95")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_R2SCAN_CIDH = SimpleKeyword(
-        "dlpno-r2scan-cidh"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_R2SCAN_QIDH = SimpleKeyword(
-        "dlpno-r2scan-qidh"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_R2SCAN0_2 = SimpleKeyword("dlpno-r2scan0-2")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_R2SCAN0_DH = SimpleKeyword(
-        "dlpno-r2scan0-dh"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_RSX_0DH = SimpleKeyword("dlpno-rsx-0dh")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_RSX_QIDH = SimpleKeyword("dlpno-rsx-qidh")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_B2GP_PLYP21 = SimpleKeyword(
-        "dlpno-scs-b2gp-plyp21"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_PBE_QIDH = SimpleKeyword(
-        "dlpno-scs-pbe-qidh"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_RSX_QIDH = SimpleKeyword(
-        "dlpno-scs-rsx-qidh"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_WB2GP_PLYP = SimpleKeyword(
-        "dlpno-scs-wb2gp-plyp"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_WB88PP86 = SimpleKeyword(
-        "dlpno-scs-wb88pp86"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_WPBEPP86 = SimpleKeyword(
-        "dlpno-scs-wpbepp86"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_SOS_B2PLYP21 = SimpleKeyword(
-        "dlpno-scs/sos-b2plyp21"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SCS_SOS_WB2PLYP = SimpleKeyword(
-        "dlpno-scs/sos-wb2plyp"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_B2GP_PLYP21 = SimpleKeyword(
-        "dlpno-sos-b2gp-plyp21"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_PBE_QIDH = SimpleKeyword(
-        "dlpno-sos-pbe-qidh"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_RSX_QIDH = SimpleKeyword(
-        "dlpno-sos-rsx-qidh"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_WB2GP_PLYP = SimpleKeyword(
-        "dlpno-sos-wb2gp-plyp"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_WB88PP86 = SimpleKeyword(
-        "dlpno-sos-wb88pp86"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_SOS_WPBEPP86 = SimpleKeyword(
-        "dlpno-sos-wpbepp86"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_WB2GP_PLYP = SimpleKeyword(
-        "dlpno-wb2gp-plyp"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_WB2PLYP = SimpleKeyword("dlpno-wb2plyp")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_WB88PP86 = SimpleKeyword("dlpno-wb88pp86")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_WB97M_2 = SimpleKeyword("dlpno-wb97m(2)")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_WB97X_2 = SimpleKeyword("dlpno-wb97x-2")  # Double-hybrid DFT with DLPNO approximation
+    B3LYP_GCP_D3_6_31GSTAR = SimpleKeyword("b3lyp-gcp-d3/6-31g*")
+    FOD = SimpleKeyword("fod")
+    B1LYP = SimpleKeyword("b1lyp")
+    B1P = SimpleKeyword("b1p")
+    B1P86 = SimpleKeyword("b1p86")
+    B1PBE = SimpleKeyword("b1pbe")
+    B1PW = SimpleKeyword("b1pw")
+    B1PW91 = SimpleKeyword("b1pw91")
+    B2GP_PLYP = SimpleKeyword("b2gp-plyp")
+    B2K_PLYP = SimpleKeyword("b2k-plyp")
+    B2PLYP = SimpleKeyword("b2plyp")
+    B2T_PLYP = SimpleKeyword("b2t-plyp")
+    B3LYP = SimpleKeyword("b3lyp")
+    B3LYP_G = SimpleKeyword("b3lyp_g")
+    B3P = SimpleKeyword("b3p")
+    B3P86 = SimpleKeyword("b3p86")
+    B3PBE = SimpleKeyword("b3pbe")
+    B3PW = SimpleKeyword("b3pw")
+    B3PW91 = SimpleKeyword("b3pw91")
+    B97 = SimpleKeyword("b97")
+    B97_D = SimpleKeyword("b97-d")
+    B97_D3 = SimpleKeyword("b97-d3")
+    B97_D4 = SimpleKeyword("b97-d4")
+    B97M_D3BJ = SimpleKeyword("b97m-d3bj")
+    B97M_D4 = SimpleKeyword("b97m-d4")
+    B97M_V = SimpleKeyword("b97m-v")
+    BHANDHLYP = SimpleKeyword("bhandhlyp")
+    BHLYP = SimpleKeyword("bhlyp")
+    BLYP = SimpleKeyword("blyp")
+    BNULL = SimpleKeyword("bnull")
+    BP86 = SimpleKeyword("bp86")
+    BPBE = SimpleKeyword("bpbe")
+    BPW = SimpleKeyword("bpw")
+    BPW91 = SimpleKeyword("bpw91")
+    BVWN = SimpleKeyword("bvwn")
+    CAM_B3LYP = SimpleKeyword("cam-b3lyp")
+    DLPNO_B2GP_PLYP = SimpleKeyword("dlpno-b2gp-plyp")
+    DLPNO_B2K_PLYP = SimpleKeyword("dlpno-b2k-plyp")
+    DLPNO_B2PLYP = SimpleKeyword("dlpno-b2plyp")
+    DLPNO_B2T_PLYP = SimpleKeyword("dlpno-b2t-plyp")
+    DLPNO_DSD_BLYP = SimpleKeyword("dlpno-dsd-blyp")
+    DLPNO_DSD_PBEB95 = SimpleKeyword("dlpno-dsd-pbeb95")
+    DLPNO_DSD_PBEP86 = SimpleKeyword("dlpno-dsd-pbep86")
+    DLPNO_KPR2SCAN50 = SimpleKeyword("dlpno-kpr2scan50")
+    DLPNO_MPW2PLYP = SimpleKeyword("dlpno-mpw2plyp")
+    DLPNO_PBE_QIDH = SimpleKeyword("dlpno-pbe-qidh")
+    DLPNO_PBE0_2 = SimpleKeyword("dlpno-pbe0-2")
+    DLPNO_PBE0_DH = SimpleKeyword("dlpno-pbe0-dh")
+    DLPNO_PR2SCAN50 = SimpleKeyword("dlpno-pr2scan50")
+    DLPNO_PR2SCAN69 = SimpleKeyword("dlpno-pr2scan69")
+    DLPNO_PWPB95 = SimpleKeyword("dlpno-pwpb95")
+    DLPNO_R2SCAN_CIDH = SimpleKeyword("dlpno-r2scan-cidh")
+    DLPNO_R2SCAN_QIDH = SimpleKeyword("dlpno-r2scan-qidh")
+    DLPNO_R2SCAN0_2 = SimpleKeyword("dlpno-r2scan0-2")
+    DLPNO_R2SCAN0_DH = SimpleKeyword("dlpno-r2scan0-dh")
+    DLPNO_RSX_0DH = SimpleKeyword("dlpno-rsx-0dh")
+    DLPNO_RSX_QIDH = SimpleKeyword("dlpno-rsx-qidh")
+    DLPNO_SCS_B2GP_PLYP21 = SimpleKeyword("dlpno-scs-b2gp-plyp21")
+    DLPNO_SCS_PBE_QIDH = SimpleKeyword("dlpno-scs-pbe-qidh")
+    DLPNO_SCS_RSX_QIDH = SimpleKeyword("dlpno-scs-rsx-qidh")
+    DLPNO_SCS_WB2GP_PLYP = SimpleKeyword("dlpno-scs-wb2gp-plyp")
+    DLPNO_SCS_WB88PP86 = SimpleKeyword("dlpno-scs-wb88pp86")
+    DLPNO_SCS_WPBEPP86 = SimpleKeyword("dlpno-scs-wpbepp86")
+    DLPNO_SCS_SOS_B2PLYP21 = SimpleKeyword("dlpno-scs/sos-b2plyp21")
+    DLPNO_SCS_SOS_WB2PLYP = SimpleKeyword("dlpno-scs/sos-wb2plyp")
+    DLPNO_SOS_B2GP_PLYP21 = SimpleKeyword("dlpno-sos-b2gp-plyp21")
+    DLPNO_SOS_PBE_QIDH = SimpleKeyword("dlpno-sos-pbe-qidh")
+    DLPNO_SOS_RSX_QIDH = SimpleKeyword("dlpno-sos-rsx-qidh")
+    DLPNO_SOS_WB2GP_PLYP = SimpleKeyword("dlpno-sos-wb2gp-plyp")
+    DLPNO_SOS_WB88PP86 = SimpleKeyword("dlpno-sos-wb88pp86")
+    DLPNO_SOS_WPBEPP86 = SimpleKeyword("dlpno-sos-wpbepp86")
+    DLPNO_WB2GP_PLYP = SimpleKeyword("dlpno-wb2gp-plyp")
+    DLPNO_WB2PLYP = SimpleKeyword("dlpno-wb2plyp")
+    DLPNO_WB88PP86 = SimpleKeyword("dlpno-wb88pp86")
+    DLPNO_WB97M_2 = SimpleKeyword("dlpno-wb97m(2)")
+    DLPNO_WB97X_2 = SimpleKeyword("dlpno-wb97x-2")
     DLPNO_WB97X_2_TQZ = SimpleKeyword(
         "dlpno-wb97x-2(tqz)"
     )  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_WPBEPP86 = SimpleKeyword("dlpno-wpbepp86")  # Double-hybrid DFT with DLPNO approximation
-    DLPNO_WPR2SCAN50 = SimpleKeyword(
-        "dlpno-wpr2scan50"
-    )  # Double-hybrid DFT with DLPNO approximation
-    DSD_BLYP = SimpleKeyword("dsd-blyp")  # DFT functional
-    DSD_PBEB95 = SimpleKeyword("dsd-pbeb95")  # DFT functional
-    DSD_PBEP86 = SimpleKeyword("dsd-pbep86")  # DFT functional
-    G1LYP = SimpleKeyword("g1lyp")  # DFT functional
-    G1P = SimpleKeyword("g1p")  # DFT functional
-    G3LYP = SimpleKeyword("g3lyp")  # DFT functional
-    G3P = SimpleKeyword("g3p")  # DFT functional
-    GLYP = SimpleKeyword("glyp")  # DFT functional
-    GP = SimpleKeyword("gp")  # DFT functional
-    HFLDA = SimpleKeyword("hflda")  # DFT functional
-    HFS = SimpleKeyword("hfs")  # DFT functional
-    KPR2SCAN50 = SimpleKeyword("kpr2scan50")  # DFT functional
-    LB94 = SimpleKeyword("lb94")  # DFT functional
-    LC_BLYP = SimpleKeyword("lc-blyp")  # DFT functional
-    LC_PBE = SimpleKeyword("lc-pbe")  # DFT functional
-    LDA = SimpleKeyword("lda")  # DFT functional
-    LRC_PBE = SimpleKeyword("lrc-pbe")  # DFT functional
-    LSD = SimpleKeyword("lsd")  # DFT functional
-    M06 = SimpleKeyword("m06")  # DFT functional
-    M062X = SimpleKeyword("m062x")  # DFT functional
-    M06L = SimpleKeyword("m06l")  # DFT functional
-    MPW1LYP = SimpleKeyword("mpw1lyp")  # DFT functional
-    MPW1PW = SimpleKeyword("mpw1pw")  # DFT functional
-    MPW2PLYP = SimpleKeyword("mpw2plyp")  # DFT functional
-    MPWLYP = SimpleKeyword("mpwlyp")  # DFT functional
-    MPWPW = SimpleKeyword("mpwpw")  # DFT functional
-    O3LYP = SimpleKeyword("o3lyp")  # DFT functional
-    OLYP = SimpleKeyword("olyp")  # DFT functional
-    OPBE = SimpleKeyword("opbe")  # DFT functional
-    PBE = SimpleKeyword("pbe")  # DFT functional
-    PBE_QIDH = SimpleKeyword("pbe-qidh")  # DFT functional
-    PBE0 = SimpleKeyword("pbe0")  # DFT functional
-    PBE0_2 = SimpleKeyword("pbe0-2")  # DFT functional
-    PBE0_DH = SimpleKeyword("pbe0-dh")  # DFT functional
-    PR2SCAN50 = SimpleKeyword("pr2scan50")  # DFT functional
-    PR2SCAN69 = SimpleKeyword("pr2scan69")  # DFT functional
-    PW1PW = SimpleKeyword("pw1pw")  # DFT functional
-    PW6B95 = SimpleKeyword("pw6b95")  # DFT functional
-    PW86PBE = SimpleKeyword("pw86pbe")  # DFT functional
-    PW91 = SimpleKeyword("pw91")  # DFT functional
-    PW91_0 = SimpleKeyword("pw91_0")  # DFT functional
-    PWLDA = SimpleKeyword("pwlda")  # DFT functional
-    PWP = SimpleKeyword("pwp")  # DFT functional
-    PWP1 = SimpleKeyword("pwp1")  # DFT functional
-    PWPB95 = SimpleKeyword("pwpb95")  # DFT functional
-    R2SCAN = SimpleKeyword("r2scan")  # DFT functional
-    R2SCAN_3C = SimpleKeyword("r2scan-3c")  # DFT functional
-    R2SCAN_CIDH = SimpleKeyword("r2scan-cidh")  # DFT functional
-    R2SCAN_QIDH = SimpleKeyword("r2scan-qidh")  # DFT functional
-    R2SCAN0 = SimpleKeyword("r2scan0")  # DFT functional
-    R2SCAN0 = SimpleKeyword("r2scan0")  # DFT functional
-    R2SCAN0_2 = SimpleKeyword("r2scan0-2")  # DFT functional
-    R2SCAN0_DH = SimpleKeyword("r2scan0-dh")  # DFT functional
-    R2SCAN50 = SimpleKeyword("r2scan50")  # DFT functional
-    R2SCANH = SimpleKeyword("r2scanh")  # DFT functional
-    REVDOD_PBEP86_D4_2021 = SimpleKeyword("revdod-pbep86-d4/2021")  # DFT functional
-    REVDOD_PBEP86_2021 = SimpleKeyword("revdod-pbep86/2021")  # DFT functional
-    REVDSD_PBEP86_D4_2021 = SimpleKeyword("revdsd-pbep86-d4/2021")  # DFT functional
-    REVDSD_PBEP86_2021 = SimpleKeyword("revdsd-pbep86/2021")  # DFT functional
-    REVPBE = SimpleKeyword("revpbe")  # DFT functional
-    REVPBE0 = SimpleKeyword("revpbe0")  # DFT functional
-    REVPBE38 = SimpleKeyword("revpbe38")  # DFT functional
-    REVTPSS = SimpleKeyword("revtpss")  # DFT functional
-    RPBE = SimpleKeyword("rpbe")  # DFT functional
-    RPW86PBE = SimpleKeyword("rpw86pbe")  # DFT functional
-    RSCAN = SimpleKeyword("rscan")  # DFT functional
-    RSX_0DH = SimpleKeyword("rsx-0dh")  # DFT functional
-    RSX_QIDH = SimpleKeyword("rsx-qidh")  # DFT functional
-    SCANFUNC = SimpleKeyword("scanfunc")  # DFT functional
-    SCS_B2GP_PLYP21 = SimpleKeyword("scs-b2gp-plyp21")  # DFT functional
-    SCS_PBE_QIDH = SimpleKeyword("scs-pbe-qidh")  # DFT functional
-    SCS_RSX_QIDH = SimpleKeyword("scs-rsx-qidh")  # DFT functional
-    SCS_WB2GP_PLYP = SimpleKeyword("scs-wb2gp-plyp")  # DFT functional
-    SCS_WB88PP86 = SimpleKeyword("scs-wb88pp86")  # DFT functional
-    SCS_WPBEPP86 = SimpleKeyword("scs-wpbepp86")  # DFT functional
-    SCS_SOS_B2PLYP21 = SimpleKeyword("scs/sos-b2plyp21")  # DFT functional
-    SCS_SOS_WB2PLYP = SimpleKeyword("scs/sos-wb2plyp")  # DFT functional
-    SOS_B2GP_PLYP21 = SimpleKeyword("sos-b2gp-plyp21")  # DFT functional
-    SOS_PBE_QIDH = SimpleKeyword("sos-pbe-qidh")  # DFT functional
-    SOS_RSX_QIDH = SimpleKeyword("sos-rsx-qidh")  # DFT functional
-    SOS_WB2GP_PLYP = SimpleKeyword("sos-wb2gp-plyp")  # DFT functional
-    SOS_WB88PP86 = SimpleKeyword("sos-wb88pp86")  # DFT functional
-    SOS_WPBEPP86 = SimpleKeyword("sos-wpbepp86")  # DFT functional
-    TPSS = SimpleKeyword("tpss")  # DFT functional
-    TPSS0 = SimpleKeyword("tpss0")  # DFT functional
-    TPSSH = SimpleKeyword("tpssh")  # DFT functional
-    VWN = SimpleKeyword("vwn")  # DFT functional
-    VWN3 = SimpleKeyword("vwn3")  # DFT functional
-    VWN5 = SimpleKeyword("vwn5")  # DFT functional
-    WB2GP_PLYP = SimpleKeyword("wb2gp-plyp")  # DFT functional
-    WB2PLYP = SimpleKeyword("wb2plyp")  # DFT functional
-    WB88PP86 = SimpleKeyword("wb88pp86")  # DFT functional
-    WB97 = SimpleKeyword("wb97")  # DFT functional
-    WB97M_D3BJ = SimpleKeyword("wb97m-d3bj")  # DFT functional
-    WB97M_D4 = SimpleKeyword("wb97m-d4")  # DFT functional
-    WB97M_D4REV = SimpleKeyword("wb97m-d4rev")  # DFT functional
-    WB97M_V = SimpleKeyword("wb97m-v")  # DFT functional
-    WB97M_2 = SimpleKeyword("wb97m(2)")  # DFT functional
-    WB97X = SimpleKeyword("wb97x")  # DFT functional
-    WB97X_2 = SimpleKeyword("wb97x-2")  # DFT functional
-    WB97X_2_TQZ = SimpleKeyword("wb97x-2(tqz)")  # DFT functional
-    WB97X_D3 = SimpleKeyword("wb97x-d3")  # DFT functional
-    WB97X_D3BJ = SimpleKeyword("wb97x-d3bj")  # DFT functional
-    WB97X_D4 = SimpleKeyword("wb97x-d4")  # DFT functional
-    WB97X_D4REV = SimpleKeyword("wb97x-d4rev")  # DFT functional
-    WB97X_V = SimpleKeyword("wb97x-v")  # DFT functional
-    WPBEPP86 = SimpleKeyword("wpbepp86")  # DFT functional
-    WPR2SCAN50 = SimpleKeyword("wpr2scan50")  # DFT functional
-    WR2SCAN = SimpleKeyword("wr2scan")  # DFT functional
-    X3LYP = SimpleKeyword("x3lyp")  # DFT functional
-    XHF = SimpleKeyword("xhf")  # DFT functional
-    XLYP = SimpleKeyword("xlyp")  # DFT functional
+    DLPNO_WPBEPP86 = SimpleKeyword("dlpno-wpbepp86")
+    DLPNO_WPR2SCAN50 = SimpleKeyword("dlpno-wpr2scan50")
+    DSD_BLYP = SimpleKeyword("dsd-blyp")
+    DSD_PBEB95 = SimpleKeyword("dsd-pbeb95")
+    DSD_PBEP86 = SimpleKeyword("dsd-pbep86")
+    G1LYP = SimpleKeyword("g1lyp")
+    G1P = SimpleKeyword("g1p")
+    G3LYP = SimpleKeyword("g3lyp")
+    G3P = SimpleKeyword("g3p")
+    GLYP = SimpleKeyword("glyp")
+    GP = SimpleKeyword("gp")
+    HFLDA = SimpleKeyword("hflda")
+    HFS = SimpleKeyword("hfs")
+    KPR2SCAN50 = SimpleKeyword("kpr2scan50")
+    LB94 = SimpleKeyword("lb94")
+    LC_BLYP = SimpleKeyword("lc-blyp")
+    LC_PBE = SimpleKeyword("lc-pbe")
+    LDA = SimpleKeyword("lda")
+    LRC_PBE = SimpleKeyword("lrc-pbe")
+    LSD = SimpleKeyword("lsd")
+    M06 = SimpleKeyword("m06")
+    M062X = SimpleKeyword("m062x")
+    M06L = SimpleKeyword("m06l")
+    MPW1LYP = SimpleKeyword("mpw1lyp")
+    MPW1PW = SimpleKeyword("mpw1pw")
+    MPW2PLYP = SimpleKeyword("mpw2plyp")
+    MPWLYP = SimpleKeyword("mpwlyp")
+    MPWPW = SimpleKeyword("mpwpw")
+    O3LYP = SimpleKeyword("o3lyp")
+    OLYP = SimpleKeyword("olyp")
+    OPBE = SimpleKeyword("opbe")
+    PBE = SimpleKeyword("pbe")
+    PBE_QIDH = SimpleKeyword("pbe-qidh")
+    PBE0 = SimpleKeyword("pbe0")
+    PBE0_2 = SimpleKeyword("pbe0-2")
+    PBE0_DH = SimpleKeyword("pbe0-dh")
+    PR2SCAN50 = SimpleKeyword("pr2scan50")
+    PR2SCAN69 = SimpleKeyword("pr2scan69")
+    PW1PW = SimpleKeyword("pw1pw")
+    PW6B95 = SimpleKeyword("pw6b95")
+    PW86PBE = SimpleKeyword("pw86pbe")
+    PW91 = SimpleKeyword("pw91")
+    PW91_0 = SimpleKeyword("pw91_0")
+    PWLDA = SimpleKeyword("pwlda")
+    PWP = SimpleKeyword("pwp")
+    PWP1 = SimpleKeyword("pwp1")
+    PWPB95 = SimpleKeyword("pwpb95")
+    R2SCAN = SimpleKeyword("r2scan")
+    R2SCAN_3C = SimpleKeyword("r2scan-3c")
+    R2SCAN_CIDH = SimpleKeyword("r2scan-cidh")
+    R2SCAN_QIDH = SimpleKeyword("r2scan-qidh")
+    R2SCAN0 = SimpleKeyword("r2scan0")
+    R2SCAN0 = SimpleKeyword("r2scan0")
+    R2SCAN0_2 = SimpleKeyword("r2scan0-2")
+    R2SCAN0_DH = SimpleKeyword("r2scan0-dh")
+    R2SCAN50 = SimpleKeyword("r2scan50")
+    R2SCANH = SimpleKeyword("r2scanh")
+    REVDOD_PBEP86_D4_2021 = SimpleKeyword("revdod-pbep86-d4/2021")
+    REVDOD_PBEP86_2021 = SimpleKeyword("revdod-pbep86/2021")
+    REVDSD_PBEP86_D4_2021 = SimpleKeyword("revdsd-pbep86-d4/2021")
+    REVDSD_PBEP86_2021 = SimpleKeyword("revdsd-pbep86/2021")
+    REVPBE = SimpleKeyword("revpbe")
+    REVPBE0 = SimpleKeyword("revpbe0")
+    REVPBE38 = SimpleKeyword("revpbe38")
+    REVTPSS = SimpleKeyword("revtpss")
+    RPBE = SimpleKeyword("rpbe")
+    RPW86PBE = SimpleKeyword("rpw86pbe")
+    RSCAN = SimpleKeyword("rscan")
+    RSX_0DH = SimpleKeyword("rsx-0dh")
+    RSX_QIDH = SimpleKeyword("rsx-qidh")
+    SCANFUNC = SimpleKeyword("scanfunc")
+    SCS_B2GP_PLYP21 = SimpleKeyword("scs-b2gp-plyp21")
+    SCS_PBE_QIDH = SimpleKeyword("scs-pbe-qidh")
+    SCS_RSX_QIDH = SimpleKeyword("scs-rsx-qidh")
+    SCS_WB2GP_PLYP = SimpleKeyword("scs-wb2gp-plyp")
+    SCS_WB88PP86 = SimpleKeyword("scs-wb88pp86")
+    SCS_WPBEPP86 = SimpleKeyword("scs-wpbepp86")
+    SCS_SOS_B2PLYP21 = SimpleKeyword("scs/sos-b2plyp21")
+    SCS_SOS_WB2PLYP = SimpleKeyword("scs/sos-wb2plyp")
+    SOS_B2GP_PLYP21 = SimpleKeyword("sos-b2gp-plyp21")
+    SOS_PBE_QIDH = SimpleKeyword("sos-pbe-qidh")
+    SOS_RSX_QIDH = SimpleKeyword("sos-rsx-qidh")
+    SOS_WB2GP_PLYP = SimpleKeyword("sos-wb2gp-plyp")
+    SOS_WB88PP86 = SimpleKeyword("sos-wb88pp86")
+    SOS_WPBEPP86 = SimpleKeyword("sos-wpbepp86")
+    TPSS = SimpleKeyword("tpss")
+    TPSS0 = SimpleKeyword("tpss0")
+    TPSSH = SimpleKeyword("tpssh")
+    VWN = SimpleKeyword("vwn")
+    VWN3 = SimpleKeyword("vwn3")
+    VWN5 = SimpleKeyword("vwn5")
+    WB2GP_PLYP = SimpleKeyword("wb2gp-plyp")
+    WB2PLYP = SimpleKeyword("wb2plyp")
+    WB88PP86 = SimpleKeyword("wb88pp86")
+    WB97 = SimpleKeyword("wb97")
+    WB97M_D3BJ = SimpleKeyword("wb97m-d3bj")
+    WB97M_D4 = SimpleKeyword("wb97m-d4")
+    WB97M_D4REV = SimpleKeyword("wb97m-d4rev")
+    WB97M_V = SimpleKeyword("wb97m-v")
+    WB97M_2 = SimpleKeyword("wb97m(2)")
+    WB97X = SimpleKeyword("wb97x")
+    WB97X_2 = SimpleKeyword("wb97x-2")
+    WB97X_2_TQZ = SimpleKeyword("wb97x-2(tqz)")
+    WB97X_D3 = SimpleKeyword("wb97x-d3")
+    WB97X_D3BJ = SimpleKeyword("wb97x-d3bj")
+    WB97X_D4 = SimpleKeyword("wb97x-d4")
+    WB97X_D4REV = SimpleKeyword("wb97x-d4rev")
+    WB97X_V = SimpleKeyword("wb97x-v")
+    WPBEPP86 = SimpleKeyword("wpbepp86")
+    WPR2SCAN50 = SimpleKeyword("wpr2scan50")
+    WR2SCAN = SimpleKeyword("wr2scan")
+    X3LYP = SimpleKeyword("x3lyp")
+    XHF = SimpleKeyword("xhf")
+    XLYP = SimpleKeyword("xlyp")

--- a/src/opi/input/simple_keywords/dft.py
+++ b/src/opi/input/simple_keywords/dft.py
@@ -12,17 +12,17 @@ class Dft(SimpleKeywordBox):
     Attributes
     ----------
     B3LYP3C : SimpleKeyword
-        DFT 3c methods, do not require dispersion correction or basis set
+        DFT 3c methods, does not require dispersion correction or basis set separately
     B973C : SimpleKeyword
-        DFT 3c methods, do not require dispersion correction or basis set
+        DFT 3c methods, does not require dispersion correction or basis set separately
     PBEH3C : SimpleKeyword
-        DFT 3c methods, do not require dispersion correction or basis set
+        DFT 3c methods, does not require dispersion correction or basis set separately
     WB97X3C : SimpleKeyword
-        DFT 3c methods, do not require dispersion correction or basis set
+        DFT 3c methods, does not require dispersion correction or basis set separately
     B3LYP_GCP_D3_6_31G_D : SimpleKeyword
         Dft
     B3LYP_GCP_D3_6_31GSTAR : SimpleKeyword
-        DFT like 3c methods, do not require dispersion correction or basis set
+        DFT - similar to 3c methods, does not require dispersion correction or basis set separately
     FOD : SimpleKeyword
         DFT with smearing for determining multireference character (TPSS/def2-TZVP, T = 5000 K)
     B1LYP : SimpleKeyword
@@ -409,9 +409,7 @@ class Dft(SimpleKeywordBox):
     B973C = SimpleKeyword("b973c")
     PBEH3C = SimpleKeyword("pbeh3c")
     WB97X3C = SimpleKeyword("wb97x3c")
-    B3LYP_GCP_D3_6_31G_D = SimpleKeyword(
-        "b3lyp-gcp-d3/6-31g(d)"
-    )  # DFT like 3c methods, do not require dispersion correction or basis set
+    B3LYP_GCP_D3_6_31G_D = SimpleKeyword("b3lyp-gcp-d3/6-31g(d)")
     B3LYP_GCP_D3_6_31GSTAR = SimpleKeyword("b3lyp-gcp-d3/6-31g*")
     FOD = SimpleKeyword("fod")
     B1LYP = SimpleKeyword("b1lyp")

--- a/src/opi/input/simple_keywords/dispersion_correction.py
+++ b/src/opi/input/simple_keywords/dispersion_correction.py
@@ -7,39 +7,25 @@ __all__ = ("DispersionCorrection",)
 
 
 class DispersionCorrection(SimpleKeywordBox):
-    """Enum to store all simple keywords of type DispersionCorrection.
-
-    Attributes
-    ----------
-    ABC : SimpleKeyword
-        Use three body term, applicable together with D3BJ.
-    D2 : SimpleKeyword
-        D2 - Dispersion correction.
-    D3 : SimpleKeyword
-        D3 - Dispersion correction.
-    D3ZERO : SimpleKeyword
-        D3 - Dispersion correction with zero damping.
-    D3BJ : SimpleKeyword
-        D3 - Dispersion correction with Becke-Johnson damping
-    D3TZ : SimpleKeyword
-        Use TZ optimized damping parameters if available
-    D4 : SimpleKeyword
-        D4 - Dispersion correction with three body term and Becke-Johnson damping
-    NL : SimpleKeyword
-        Use -NL / -VV10 / -V dispersion correction
-    POPDISP : SimpleKeyword
-        Pairwise dispersion correction analysis
-    SCNL : SimpleKeyword
-        Use self-consistent NL
-    """
+    """Enum to store all simple keywords of type DispersionCorrection."""
 
     ABC = SimpleKeyword("abc")
+    """SimpleKeyword: Use three body term, applicable together with D3BJ.."""
     D2 = SimpleKeyword("d2")
+    """SimpleKeyword: D2 - Dispersion correction.."""
     D3 = SimpleKeyword("d3")
+    """SimpleKeyword: D3 - Dispersion correction.."""
     D3ZERO = SimpleKeyword("d3zero")
+    """SimpleKeyword: D3 - Dispersion correction with zero damping.."""
     D3BJ = SimpleKeyword("d3bj")
+    """SimpleKeyword: D3 - Dispersion correction with Becke-Johnson damping."""
     D3TZ = SimpleKeyword("d3tz")
+    """SimpleKeyword: Use TZ optimized damping parameters if available."""
     D4 = SimpleKeyword("d4")
+    """SimpleKeyword: D4 - Dispersion correction with three body term and Becke-Johnson damping."""
     NL = SimpleKeyword("nl")
+    """SimpleKeyword: Use -NL / -VV10 / -V dispersion correction."""
     POPDISP = SimpleKeyword("popdisp")
+    """SimpleKeyword: Pairwise dispersion correction analysis."""
     SCNL = SimpleKeyword("scnl")
+    """SimpleKeyword: Use self-consistent NL."""

--- a/src/opi/input/simple_keywords/dispersion_correction.py
+++ b/src/opi/input/simple_keywords/dispersion_correction.py
@@ -7,15 +7,39 @@ __all__ = ("DispersionCorrection",)
 
 
 class DispersionCorrection(SimpleKeywordBox):
-    """Enum to store all simple keywords of type DispersionCorrection"""
+    """Enum to store all simple keywords of type DispersionCorrection.
 
-    ABC = SimpleKeyword("abc")  # three body term for d3bj
-    D2 = SimpleKeyword("d2")  # D2
-    D3 = SimpleKeyword("d3")  # D3
-    D3ZERO = SimpleKeyword("d3zero")  # D3 Zero damping
-    D3BJ = SimpleKeyword("d3bj")  # D3 with BJ damping
-    D3TZ = SimpleKeyword("d3tz")  # Use TZ optimized values damping parameters if available
-    D4 = SimpleKeyword("d4")  # Use D4 dispersion correction
-    NL = SimpleKeyword("nl")  # use -NL / -VV10 / -V dispersion correction
-    POPDISP = SimpleKeyword("popdisp")  # pairwise dispersion correction analysis
-    SCNL = SimpleKeyword("scnl")  # Use self-consistent nl
+    Attributes
+    ----------
+    ABC : SimpleKeyword
+        three body term for d3bj
+    D2 : SimpleKeyword
+        D2
+    D3 : SimpleKeyword
+        D3
+    D3ZERO : SimpleKeyword
+        D3 Zero damping
+    D3BJ : SimpleKeyword
+        D3 with BJ damping
+    D3TZ : SimpleKeyword
+        Use TZ optimized values damping parameters if available
+    D4 : SimpleKeyword
+        Use D4 dispersion correction
+    NL : SimpleKeyword
+        use -NL / -VV10 / -V dispersion correction
+    POPDISP : SimpleKeyword
+        pairwise dispersion correction analysis
+    SCNL : SimpleKeyword
+        Use self-consistent nl
+    """
+
+    ABC = SimpleKeyword("abc")
+    D2 = SimpleKeyword("d2")
+    D3 = SimpleKeyword("d3")
+    D3ZERO = SimpleKeyword("d3zero")
+    D3BJ = SimpleKeyword("d3bj")
+    D3TZ = SimpleKeyword("d3tz")
+    D4 = SimpleKeyword("d4")
+    NL = SimpleKeyword("nl")
+    POPDISP = SimpleKeyword("popdisp")
+    SCNL = SimpleKeyword("scnl")

--- a/src/opi/input/simple_keywords/dispersion_correction.py
+++ b/src/opi/input/simple_keywords/dispersion_correction.py
@@ -12,25 +12,25 @@ class DispersionCorrection(SimpleKeywordBox):
     Attributes
     ----------
     ABC : SimpleKeyword
-        three body term for d3bj
+        Use three body term, applicable together with D3BJ.
     D2 : SimpleKeyword
-        D2
+        D2 - Dispersion correction.
     D3 : SimpleKeyword
-        D3
+        D3 - Dispersion correction.
     D3ZERO : SimpleKeyword
-        D3 Zero damping
+        D3 - Dispersion correction with zero damping.
     D3BJ : SimpleKeyword
-        D3 with BJ damping
+        D3 - Dispersion correction with Becke-Johnson damping
     D3TZ : SimpleKeyword
-        Use TZ optimized values damping parameters if available
+        Use TZ optimized damping parameters if available
     D4 : SimpleKeyword
-        Use D4 dispersion correction
+        D4 - Dispersion correction with three body term and Becke-Johnson damping
     NL : SimpleKeyword
-        use -NL / -VV10 / -V dispersion correction
+        Use -NL / -VV10 / -V dispersion correction
     POPDISP : SimpleKeyword
-        pairwise dispersion correction analysis
+        Pairwise dispersion correction analysis
     SCNL : SimpleKeyword
-        Use self-consistent nl
+        Use self-consistent NL
     """
 
     ABC = SimpleKeyword("abc")

--- a/src/opi/input/simple_keywords/dlpno.py
+++ b/src/opi/input/simple_keywords/dlpno.py
@@ -7,30 +7,19 @@ __all__ = ("Dlpno",)
 
 
 class Dlpno(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Dlpno.
-
-    Attributes
-    ----------
-    HFLD : SimpleKeyword
-        HF + Dispersion energy
-    LED : SimpleKeyword
-        Energy decomposition for DLPNO-CC methods.
-    LOOSEPNO : SimpleKeyword
-        Select loose PNO settings.
-    NORMALPNO : SimpleKeyword
-        Select normal PNO settings.
-    TIGHTPNO : SimpleKeyword
-        Select Tight PNO settings.
-    ADLD : SimpleKeyword
-        Atomic decomposition of the London Dispersion energy.
-    PNOEXTRAPOLATION : SimpleKeyword
-        Automatic extrapolation of PNO space.
-    """
+    """Enum to store all simple keywords of type Dlpno."""
 
     HFLD = SimpleKeyword("hfld")
+    """SimpleKeyword: HF + Dispersion energy."""
     LED = SimpleKeyword("led")
+    """SimpleKeyword: Energy decomposition for DLPNO-CC methods.."""
     LOOSEPNO = SimpleKeyword("loosepno")
+    """SimpleKeyword: Select loose PNO settings.."""
     NORMALPNO = SimpleKeyword("normalpno")
+    """SimpleKeyword: Select normal PNO settings.."""
     TIGHTPNO = SimpleKeyword("tightpno")
+    """SimpleKeyword: Select Tight PNO settings.."""
     ADLD = SimpleKeyword("adld")
+    """SimpleKeyword: Atomic decomposition of the London Dispersion energy.."""
     PNOEXTRAPOLATION = SimpleKeyword("pnoextrapolation")
+    """SimpleKeyword: Automatic extrapolation of PNO space.."""

--- a/src/opi/input/simple_keywords/dlpno.py
+++ b/src/opi/input/simple_keywords/dlpno.py
@@ -12,19 +12,19 @@ class Dlpno(SimpleKeywordBox):
     Attributes
     ----------
     HFLD : SimpleKeyword
-        HF + Dispersion energy decomposition  as cheaper alternative to DLPNO-CCSD(T) LED
+        HF + Dispersion energy
     LED : SimpleKeyword
-        Energy decomposition for DLPNO-CCSD(T)
+        Energy decomposition for DLPNO-CC methods.
     LOOSEPNO : SimpleKeyword
-        loose PNO settings
+        Select loose PNO settings.
     NORMALPNO : SimpleKeyword
-        normal PNO settings
+        Select normal PNO settings.
     TIGHTPNO : SimpleKeyword
-        Tight PNO settings
+        Select Tight PNO settings.
     ADLD : SimpleKeyword
-        Dlpno
+        Atomic decomposition of the London Dispersion energy.
     PNOEXTRAPOLATION : SimpleKeyword
-        automatic extrapolation of PNO space
+        Automatic extrapolation of PNO space.
     """
 
     HFLD = SimpleKeyword("hfld")

--- a/src/opi/input/simple_keywords/dlpno.py
+++ b/src/opi/input/simple_keywords/dlpno.py
@@ -7,14 +7,30 @@ __all__ = ("Dlpno",)
 
 
 class Dlpno(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Dlpno"""
+    """Enum to store all simple keywords of type Dlpno.
 
-    HFLD = SimpleKeyword(
-        "hfld"
-    )  # HF + Dispersion energy decomposition  as cheaper alternative to DLPNO-CCSD(T) LED
-    LED = SimpleKeyword("led")  # Energy decomposition for DLPNO-CCSD(T)
-    LOOSEPNO = SimpleKeyword("loosepno")  # loose PNO settings
-    NORMALPNO = SimpleKeyword("normalpno")  # normal PNO settings
-    TIGHTPNO = SimpleKeyword("tightpno")  # Tight PNO settings
+    Attributes
+    ----------
+    HFLD : SimpleKeyword
+        HF + Dispersion energy decomposition  as cheaper alternative to DLPNO-CCSD(T) LED
+    LED : SimpleKeyword
+        Energy decomposition for DLPNO-CCSD(T)
+    LOOSEPNO : SimpleKeyword
+        loose PNO settings
+    NORMALPNO : SimpleKeyword
+        normal PNO settings
+    TIGHTPNO : SimpleKeyword
+        Tight PNO settings
+    ADLD : SimpleKeyword
+        Dlpno
+    PNOEXTRAPOLATION : SimpleKeyword
+        automatic extrapolation of PNO space
+    """
+
+    HFLD = SimpleKeyword("hfld")
+    LED = SimpleKeyword("led")
+    LOOSEPNO = SimpleKeyword("loosepno")
+    NORMALPNO = SimpleKeyword("normalpno")
+    TIGHTPNO = SimpleKeyword("tightpno")
     ADLD = SimpleKeyword("adld")
-    PNOEXTRAPOLATION = SimpleKeyword("pnoextrapolation")  # automatic extrapolation of PNO space
+    PNOEXTRAPOLATION = SimpleKeyword("pnoextrapolation")

--- a/src/opi/input/simple_keywords/docker.py
+++ b/src/opi/input/simple_keywords/docker.py
@@ -7,72 +7,47 @@ __all__ = ("Docker",)
 
 
 class Docker(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Docker.
-
-    Attributes
-    ----------
-    NORMALDOCK : SimpleKeyword
-        Docker Methods
-    COMPLETEDOCK : SimpleKeyword
-        Docker Methods
-    DOCK_GFN_FF : SimpleKeyword
-        Docker Methods
-    DOCK_GFN0_XTB : SimpleKeyword
-        Docker Methods
-    DOCK_GFN1_XTB : SimpleKeyword
-        Docker Methods
-    DOCK_GFN2_XTB : SimpleKeyword
-        Docker Methods
-    DOCK_GFNFF : SimpleKeyword
-        Docker Methods
-    DOCK_XTB : SimpleKeyword
-        Docker Methods
-    DOCK_XTB0 : SimpleKeyword
-        Docker Methods
-    DOCK_XTB1 : SimpleKeyword
-        Docker Methods
-    DOCKER : SimpleKeyword
-        GOAT Methods
-    DOCKER_GFN_FF : SimpleKeyword
-        Docker Methods
-    DOCKER_GFN0_XTB : SimpleKeyword
-        Docker Methods
-    DOCKER_GFN1_XTB : SimpleKeyword
-        Docker Methods
-    DOCKER_GFN2_XTB : SimpleKeyword
-        Docker Methods
-    DOCKER_GFNFF : SimpleKeyword
-        Docker Methods
-    DOCKER_XTB : SimpleKeyword
-        Docker Methods
-    DOCKER_XTB0 : SimpleKeyword
-        Docker Methods
-    DOCKER_XTB1 : SimpleKeyword
-        Docker Methods
-    QUICKDOCK : SimpleKeyword
-        Docker Methods
-    SCREENDOCK : SimpleKeyword
-        Docker Methods
-    """
+    """Enum to store all simple keywords of type Docker."""
 
     NORMALDOCK = SimpleKeyword("normaldock")
+    """SimpleKeyword: Docker Methods."""
     COMPLETEDOCK = SimpleKeyword("completedock")
+    """SimpleKeyword: Docker Methods."""
     DOCK_GFN_FF = SimpleKeyword("dock(gfn-ff)")
+    """SimpleKeyword: Docker Methods."""
     DOCK_GFN0_XTB = SimpleKeyword("dock(gfn0-xtb)")
+    """SimpleKeyword: Docker Methods."""
     DOCK_GFN1_XTB = SimpleKeyword("dock(gfn1-xtb)")
+    """SimpleKeyword: Docker Methods."""
     DOCK_GFN2_XTB = SimpleKeyword("dock(gfn2-xtb)")
+    """SimpleKeyword: Docker Methods."""
     DOCK_GFNFF = SimpleKeyword("dock(gfnff)")
+    """SimpleKeyword: Docker Methods."""
     DOCK_XTB = SimpleKeyword("dock(xtb)")
+    """SimpleKeyword: Docker Methods."""
     DOCK_XTB0 = SimpleKeyword("dock(xtb0)")
+    """SimpleKeyword: Docker Methods."""
     DOCK_XTB1 = SimpleKeyword("dock(xtb1)")
+    """SimpleKeyword: Docker Methods."""
     DOCKER = SimpleKeyword("docker")
+    """SimpleKeyword: GOAT Methods."""
     DOCKER_GFN_FF = SimpleKeyword("docker(gfn-ff)")
+    """SimpleKeyword: Docker Methods."""
     DOCKER_GFN0_XTB = SimpleKeyword("docker(gfn0-xtb)")
+    """SimpleKeyword: Docker Methods."""
     DOCKER_GFN1_XTB = SimpleKeyword("docker(gfn1-xtb)")
+    """SimpleKeyword: Docker Methods."""
     DOCKER_GFN2_XTB = SimpleKeyword("docker(gfn2-xtb)")
+    """SimpleKeyword: Docker Methods."""
     DOCKER_GFNFF = SimpleKeyword("docker(gfnff)")
+    """SimpleKeyword: Docker Methods."""
     DOCKER_XTB = SimpleKeyword("docker(xtb)")
+    """SimpleKeyword: Docker Methods."""
     DOCKER_XTB0 = SimpleKeyword("docker(xtb0)")
+    """SimpleKeyword: Docker Methods."""
     DOCKER_XTB1 = SimpleKeyword("docker(xtb1)")
+    """SimpleKeyword: Docker Methods."""
     QUICKDOCK = SimpleKeyword("quickdock")
+    """SimpleKeyword: Docker Methods."""
     SCREENDOCK = SimpleKeyword("screendock")
+    """SimpleKeyword: Docker Methods."""

--- a/src/opi/input/simple_keywords/docker.py
+++ b/src/opi/input/simple_keywords/docker.py
@@ -7,26 +7,72 @@ __all__ = ("Docker",)
 
 
 class Docker(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Docker"""
+    """Enum to store all simple keywords of type Docker.
 
-    NORMALDOCK = SimpleKeyword("normaldock")  # Docker Methods
-    COMPLETEDOCK = SimpleKeyword("completedock")  # Docker Methods
-    DOCK_GFN_FF = SimpleKeyword("dock(gfn-ff)")  # Docker Methods
-    DOCK_GFN0_XTB = SimpleKeyword("dock(gfn0-xtb)")  # Docker Methods
-    DOCK_GFN1_XTB = SimpleKeyword("dock(gfn1-xtb)")  # Docker Methods
-    DOCK_GFN2_XTB = SimpleKeyword("dock(gfn2-xtb)")  # Docker Methods
-    DOCK_GFNFF = SimpleKeyword("dock(gfnff)")  # Docker Methods
-    DOCK_XTB = SimpleKeyword("dock(xtb)")  # Docker Methods
-    DOCK_XTB0 = SimpleKeyword("dock(xtb0)")  # Docker Methods
-    DOCK_XTB1 = SimpleKeyword("dock(xtb1)")  # Docker Methods
-    DOCKER = SimpleKeyword("docker")  # GOAT Methods
-    DOCKER_GFN_FF = SimpleKeyword("docker(gfn-ff)")  # Docker Methods
-    DOCKER_GFN0_XTB = SimpleKeyword("docker(gfn0-xtb)")  # Docker Methods
-    DOCKER_GFN1_XTB = SimpleKeyword("docker(gfn1-xtb)")  # Docker Methods
-    DOCKER_GFN2_XTB = SimpleKeyword("docker(gfn2-xtb)")  # Docker Methods
-    DOCKER_GFNFF = SimpleKeyword("docker(gfnff)")  # Docker Methods
-    DOCKER_XTB = SimpleKeyword("docker(xtb)")  # Docker Methods
-    DOCKER_XTB0 = SimpleKeyword("docker(xtb0)")  # Docker Methods
-    DOCKER_XTB1 = SimpleKeyword("docker(xtb1)")  # Docker Methods
-    QUICKDOCK = SimpleKeyword("quickdock")  # Docker Methods
-    SCREENDOCK = SimpleKeyword("screendock")  # Docker Methods
+    Attributes
+    ----------
+    NORMALDOCK : SimpleKeyword
+        Docker Methods
+    COMPLETEDOCK : SimpleKeyword
+        Docker Methods
+    DOCK_GFN_FF : SimpleKeyword
+        Docker Methods
+    DOCK_GFN0_XTB : SimpleKeyword
+        Docker Methods
+    DOCK_GFN1_XTB : SimpleKeyword
+        Docker Methods
+    DOCK_GFN2_XTB : SimpleKeyword
+        Docker Methods
+    DOCK_GFNFF : SimpleKeyword
+        Docker Methods
+    DOCK_XTB : SimpleKeyword
+        Docker Methods
+    DOCK_XTB0 : SimpleKeyword
+        Docker Methods
+    DOCK_XTB1 : SimpleKeyword
+        Docker Methods
+    DOCKER : SimpleKeyword
+        GOAT Methods
+    DOCKER_GFN_FF : SimpleKeyword
+        Docker Methods
+    DOCKER_GFN0_XTB : SimpleKeyword
+        Docker Methods
+    DOCKER_GFN1_XTB : SimpleKeyword
+        Docker Methods
+    DOCKER_GFN2_XTB : SimpleKeyword
+        Docker Methods
+    DOCKER_GFNFF : SimpleKeyword
+        Docker Methods
+    DOCKER_XTB : SimpleKeyword
+        Docker Methods
+    DOCKER_XTB0 : SimpleKeyword
+        Docker Methods
+    DOCKER_XTB1 : SimpleKeyword
+        Docker Methods
+    QUICKDOCK : SimpleKeyword
+        Docker Methods
+    SCREENDOCK : SimpleKeyword
+        Docker Methods
+    """
+
+    NORMALDOCK = SimpleKeyword("normaldock")
+    COMPLETEDOCK = SimpleKeyword("completedock")
+    DOCK_GFN_FF = SimpleKeyword("dock(gfn-ff)")
+    DOCK_GFN0_XTB = SimpleKeyword("dock(gfn0-xtb)")
+    DOCK_GFN1_XTB = SimpleKeyword("dock(gfn1-xtb)")
+    DOCK_GFN2_XTB = SimpleKeyword("dock(gfn2-xtb)")
+    DOCK_GFNFF = SimpleKeyword("dock(gfnff)")
+    DOCK_XTB = SimpleKeyword("dock(xtb)")
+    DOCK_XTB0 = SimpleKeyword("dock(xtb0)")
+    DOCK_XTB1 = SimpleKeyword("dock(xtb1)")
+    DOCKER = SimpleKeyword("docker")
+    DOCKER_GFN_FF = SimpleKeyword("docker(gfn-ff)")
+    DOCKER_GFN0_XTB = SimpleKeyword("docker(gfn0-xtb)")
+    DOCKER_GFN1_XTB = SimpleKeyword("docker(gfn1-xtb)")
+    DOCKER_GFN2_XTB = SimpleKeyword("docker(gfn2-xtb)")
+    DOCKER_GFNFF = SimpleKeyword("docker(gfnff)")
+    DOCKER_XTB = SimpleKeyword("docker(xtb)")
+    DOCKER_XTB0 = SimpleKeyword("docker(xtb0)")
+    DOCKER_XTB1 = SimpleKeyword("docker(xtb1)")
+    QUICKDOCK = SimpleKeyword("quickdock")
+    SCREENDOCK = SimpleKeyword("screendock")

--- a/src/opi/input/simple_keywords/ecp.py
+++ b/src/opi/input/simple_keywords/ecp.py
@@ -7,48 +7,31 @@ __all__ = ("Ecp",)
 
 
 class Ecp(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Ecp.
-
-    Attributes
-    ----------
-    CRENBL_ECP : SimpleKeyword
-        effective core potentials
-    DEFECP : SimpleKeyword
-        effective core potentials
-    DEF2ECP : SimpleKeyword
-        effective core potentials
-    DEF2_SD : SimpleKeyword
-        effective core potentials
-    DHF_ECP : SimpleKeyword
-        effective core potentials
-    DHFECP : SimpleKeyword
-        effective core potentials
-    HAYWADT : SimpleKeyword
-        effective core potentials
-    LANL1 : SimpleKeyword
-        effective core potentials
-    LANL2 : SimpleKeyword
-        effective core potentials
-    SDD : SimpleKeyword
-        effective core potentials
-    SK_MCDHF_RSC : SimpleKeyword
-        effective core potentials
-    VDZP_ECP : SimpleKeyword
-        effective core potentials
-    DEF2ECP_DEFECP_R2SCAN3C : SimpleKeyword
-        effective core potentials (for r²SCAN-3c)s
-    """
+    """Enum to store all simple keywords of type Ecp."""
 
     CRENBL_ECP = SimpleKeyword("crenbl-ecp")
+    """SimpleKeyword: effective core potentials."""
     DEFECP = SimpleKeyword("defecp")
+    """SimpleKeyword: effective core potentials."""
     DEF2ECP = SimpleKeyword("def2ecp")
+    """SimpleKeyword: effective core potentials."""
     DEF2_SD = SimpleKeyword("def2-sd")
+    """SimpleKeyword: effective core potentials."""
     DHF_ECP = SimpleKeyword("dhf-ecp")
+    """SimpleKeyword: effective core potentials."""
     DHFECP = SimpleKeyword("dhfecp")
+    """SimpleKeyword: effective core potentials."""
     HAYWADT = SimpleKeyword("haywadt")
+    """SimpleKeyword: effective core potentials."""
     LANL1 = SimpleKeyword("lanl1")
+    """SimpleKeyword: effective core potentials."""
     LANL2 = SimpleKeyword("lanl2")
+    """SimpleKeyword: effective core potentials."""
     SDD = SimpleKeyword("sdd")
+    """SimpleKeyword: effective core potentials."""
     SK_MCDHF_RSC = SimpleKeyword("sk-mcdhf-rsc")
+    """SimpleKeyword: effective core potentials."""
     VDZP_ECP = SimpleKeyword("vdzp-ecp")
+    """SimpleKeyword: effective core potentials."""
     DEF2ECP_DEFECP_R2SCAN3C = SimpleKeyword("def2ecp/defecp/r2scan3c")
+    """SimpleKeyword: effective core potentials (for r²SCAN-3c)s."""

--- a/src/opi/input/simple_keywords/ecp.py
+++ b/src/opi/input/simple_keywords/ecp.py
@@ -7,20 +7,48 @@ __all__ = ("Ecp",)
 
 
 class Ecp(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Ecp"""
+    """Enum to store all simple keywords of type Ecp.
 
-    CRENBL_ECP = SimpleKeyword("crenbl-ecp")  # effective core potentials
-    DEFECP = SimpleKeyword("defecp")  # effective core potentials
-    DEF2ECP = SimpleKeyword("def2ecp")  # effective core potentials
-    DEF2_SD = SimpleKeyword("def2-sd")  # effective core potentials
-    DHF_ECP = SimpleKeyword("dhf-ecp")  # effective core potentials
-    DHFECP = SimpleKeyword("dhfecp")  # effective core potentials
-    HAYWADT = SimpleKeyword("haywadt")  # effective core potentials
-    LANL1 = SimpleKeyword("lanl1")  # effective core potentials
-    LANL2 = SimpleKeyword("lanl2")  # effective core potentials
-    SDD = SimpleKeyword("sdd")  # effective core potentials
-    SK_MCDHF_RSC = SimpleKeyword("sk-mcdhf-rsc")  # effective core potentials
-    VDZP_ECP = SimpleKeyword("vdzp-ecp")  # effective core potentials
-    DEF2ECP_DEFECP_R2SCAN3C = SimpleKeyword(
-        "def2ecp/defecp/r2scan3c"
-    )  # effective core potentials (for r²SCAN-3c)s
+    Attributes
+    ----------
+    CRENBL_ECP : SimpleKeyword
+        effective core potentials
+    DEFECP : SimpleKeyword
+        effective core potentials
+    DEF2ECP : SimpleKeyword
+        effective core potentials
+    DEF2_SD : SimpleKeyword
+        effective core potentials
+    DHF_ECP : SimpleKeyword
+        effective core potentials
+    DHFECP : SimpleKeyword
+        effective core potentials
+    HAYWADT : SimpleKeyword
+        effective core potentials
+    LANL1 : SimpleKeyword
+        effective core potentials
+    LANL2 : SimpleKeyword
+        effective core potentials
+    SDD : SimpleKeyword
+        effective core potentials
+    SK_MCDHF_RSC : SimpleKeyword
+        effective core potentials
+    VDZP_ECP : SimpleKeyword
+        effective core potentials
+    DEF2ECP_DEFECP_R2SCAN3C : SimpleKeyword
+        effective core potentials (for r²SCAN-3c)s
+    """
+
+    CRENBL_ECP = SimpleKeyword("crenbl-ecp")
+    DEFECP = SimpleKeyword("defecp")
+    DEF2ECP = SimpleKeyword("def2ecp")
+    DEF2_SD = SimpleKeyword("def2-sd")
+    DHF_ECP = SimpleKeyword("dhf-ecp")
+    DHFECP = SimpleKeyword("dhfecp")
+    HAYWADT = SimpleKeyword("haywadt")
+    LANL1 = SimpleKeyword("lanl1")
+    LANL2 = SimpleKeyword("lanl2")
+    SDD = SimpleKeyword("sdd")
+    SK_MCDHF_RSC = SimpleKeyword("sk-mcdhf-rsc")
+    VDZP_ECP = SimpleKeyword("vdzp-ecp")
+    DEF2ECP_DEFECP_R2SCAN3C = SimpleKeyword("def2ecp/defecp/r2scan3c")

--- a/src/opi/input/simple_keywords/esd.py
+++ b/src/opi/input/simple_keywords/esd.py
@@ -7,17 +7,45 @@ __all__ = ("Esd",)
 
 
 class Esd(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Esd"""
+    """Enum to store all simple keywords of type Esd.
 
-    ESD = SimpleKeyword("esd")  # Check for excited state dynamics calculation
-    ESD_ABS = SimpleKeyword("esd(abs)")  # Check for excited state dynamics calculation
-    ESD_CPF = SimpleKeyword("esd(cpf)")  # Check for excited state dynamics calculation
-    ESD_CPP = SimpleKeyword("esd(cpp)")  # Check for excited state dynamics calculation
-    ESD_ECD = SimpleKeyword("esd(ecd)")  # Check for excited state dynamics calculation
-    ESD_FLUOR = SimpleKeyword("esd(fluor)")  # Check for excited state dynamics calculation
-    ESD_IC = SimpleKeyword("esd(ic)")  # Check for excited state dynamics calculation
-    ESD_ISC = SimpleKeyword("esd(isc)")  # Check for excited state dynamics calculation
-    ESD_MCD = SimpleKeyword("esd(mcd)")  # Check for excited state dynamics calculation
-    ESD_PHOSP = SimpleKeyword("esd(phosp)")  # Check for excited state dynamics calculation
-    ESD_RR = SimpleKeyword("esd(rr)")  # Check for excited state dynamics calculation
-    ESD_RRAMAN = SimpleKeyword("esd(rraman)")  # Check for excited state dynamics calculation
+    Attributes
+    ----------
+    ESD : SimpleKeyword
+        Check for excited state dynamics calculation
+    ESD_ABS : SimpleKeyword
+        Check for excited state dynamics calculation
+    ESD_CPF : SimpleKeyword
+        Check for excited state dynamics calculation
+    ESD_CPP : SimpleKeyword
+        Check for excited state dynamics calculation
+    ESD_ECD : SimpleKeyword
+        Check for excited state dynamics calculation
+    ESD_FLUOR : SimpleKeyword
+        Check for excited state dynamics calculation
+    ESD_IC : SimpleKeyword
+        Check for excited state dynamics calculation
+    ESD_ISC : SimpleKeyword
+        Check for excited state dynamics calculation
+    ESD_MCD : SimpleKeyword
+        Check for excited state dynamics calculation
+    ESD_PHOSP : SimpleKeyword
+        Check for excited state dynamics calculation
+    ESD_RR : SimpleKeyword
+        Check for excited state dynamics calculation
+    ESD_RRAMAN : SimpleKeyword
+        Check for excited state dynamics calculation
+    """
+
+    ESD = SimpleKeyword("esd")
+    ESD_ABS = SimpleKeyword("esd(abs)")
+    ESD_CPF = SimpleKeyword("esd(cpf)")
+    ESD_CPP = SimpleKeyword("esd(cpp)")
+    ESD_ECD = SimpleKeyword("esd(ecd)")
+    ESD_FLUOR = SimpleKeyword("esd(fluor)")
+    ESD_IC = SimpleKeyword("esd(ic)")
+    ESD_ISC = SimpleKeyword("esd(isc)")
+    ESD_MCD = SimpleKeyword("esd(mcd)")
+    ESD_PHOSP = SimpleKeyword("esd(phosp)")
+    ESD_RR = SimpleKeyword("esd(rr)")
+    ESD_RRAMAN = SimpleKeyword("esd(rraman)")

--- a/src/opi/input/simple_keywords/esd.py
+++ b/src/opi/input/simple_keywords/esd.py
@@ -7,45 +7,29 @@ __all__ = ("Esd",)
 
 
 class Esd(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Esd.
-
-    Attributes
-    ----------
-    ESD : SimpleKeyword
-        Check for excited state dynamics calculation
-    ESD_ABS : SimpleKeyword
-        Check for excited state dynamics calculation
-    ESD_CPF : SimpleKeyword
-        Check for excited state dynamics calculation
-    ESD_CPP : SimpleKeyword
-        Check for excited state dynamics calculation
-    ESD_ECD : SimpleKeyword
-        Check for excited state dynamics calculation
-    ESD_FLUOR : SimpleKeyword
-        Check for excited state dynamics calculation
-    ESD_IC : SimpleKeyword
-        Check for excited state dynamics calculation
-    ESD_ISC : SimpleKeyword
-        Check for excited state dynamics calculation
-    ESD_MCD : SimpleKeyword
-        Check for excited state dynamics calculation
-    ESD_PHOSP : SimpleKeyword
-        Check for excited state dynamics calculation
-    ESD_RR : SimpleKeyword
-        Check for excited state dynamics calculation
-    ESD_RRAMAN : SimpleKeyword
-        Check for excited state dynamics calculation
-    """
+    """Enum to store all simple keywords of type Esd."""
 
     ESD = SimpleKeyword("esd")
+    """SimpleKeyword: Check for excited state dynamics calculation."""
     ESD_ABS = SimpleKeyword("esd(abs)")
+    """SimpleKeyword: Check for excited state dynamics calculation."""
     ESD_CPF = SimpleKeyword("esd(cpf)")
+    """SimpleKeyword: Check for excited state dynamics calculation."""
     ESD_CPP = SimpleKeyword("esd(cpp)")
+    """SimpleKeyword: Check for excited state dynamics calculation."""
     ESD_ECD = SimpleKeyword("esd(ecd)")
+    """SimpleKeyword: Check for excited state dynamics calculation."""
     ESD_FLUOR = SimpleKeyword("esd(fluor)")
+    """SimpleKeyword: Check for excited state dynamics calculation."""
     ESD_IC = SimpleKeyword("esd(ic)")
+    """SimpleKeyword: Check for excited state dynamics calculation."""
     ESD_ISC = SimpleKeyword("esd(isc)")
+    """SimpleKeyword: Check for excited state dynamics calculation."""
     ESD_MCD = SimpleKeyword("esd(mcd)")
+    """SimpleKeyword: Check for excited state dynamics calculation."""
     ESD_PHOSP = SimpleKeyword("esd(phosp)")
+    """SimpleKeyword: Check for excited state dynamics calculation."""
     ESD_RR = SimpleKeyword("esd(rr)")
+    """SimpleKeyword: Check for excited state dynamics calculation."""
     ESD_RRAMAN = SimpleKeyword("esd(rraman)")
+    """SimpleKeyword: Check for excited state dynamics calculation."""

--- a/src/opi/input/simple_keywords/external_tools.py
+++ b/src/opi/input/simple_keywords/external_tools.py
@@ -8,6 +8,12 @@ __all__ = ("ExternalTools",)
 
 
 class ExternalTools(SimpleKeywordBox):
-    """Enum to store all simple keywords of type ExternalTools"""
+    """Enum to store all simple keywords of type ExternalTools.
 
-    EXTOPT = SimpleKeyword("extopt")  # Use external energy/gradient
+    Attributes
+    ----------
+    EXTOPT : SimpleKeyword
+        Use external energy/gradient
+    """
+
+    EXTOPT = SimpleKeyword("extopt")

--- a/src/opi/input/simple_keywords/external_tools.py
+++ b/src/opi/input/simple_keywords/external_tools.py
@@ -8,12 +8,7 @@ __all__ = ("ExternalTools",)
 
 
 class ExternalTools(SimpleKeywordBox):
-    """Enum to store all simple keywords of type ExternalTools.
-
-    Attributes
-    ----------
-    EXTOPT : SimpleKeyword
-        Use external energy/gradient
-    """
+    """Enum to store all simple keywords of type ExternalTools."""
 
     EXTOPT = SimpleKeyword("extopt")
+    """SimpleKeyword: Use external energy/gradient."""

--- a/src/opi/input/simple_keywords/force_field.py
+++ b/src/opi/input/simple_keywords/force_field.py
@@ -15,10 +15,7 @@ class ForceField(SimpleKeywordBox):
         GFN-FF (external) alias is xtb-ff
     MM : SimpleKeyword
         Use external molecular mechanics
-    SURFF : SimpleKeyword
-        Use SURFF
     """
 
     GFN_FF = SimpleKeyword("gfn-ff")
     MM = SimpleKeyword("mm")
-    SURFF = SimpleKeyword("surff")

--- a/src/opi/input/simple_keywords/force_field.py
+++ b/src/opi/input/simple_keywords/force_field.py
@@ -7,8 +7,18 @@ __all__ = ("ForceField",)
 
 
 class ForceField(SimpleKeywordBox):
-    """Enum to store all simple keywords of type ForceField"""
+    """Enum to store all simple keywords of type ForceField.
 
-    GFN_FF = SimpleKeyword("gfn-ff")  # GFN-FF (external) alias is xtb-ff
-    MM = SimpleKeyword("mm")  # Use external molecular mechanics
-    SURFF = SimpleKeyword("surff")  # Use SURFF
+    Attributes
+    ----------
+    GFN_FF : SimpleKeyword
+        GFN-FF (external) alias is xtb-ff
+    MM : SimpleKeyword
+        Use external molecular mechanics
+    SURFF : SimpleKeyword
+        Use SURFF
+    """
+
+    GFN_FF = SimpleKeyword("gfn-ff")
+    MM = SimpleKeyword("mm")
+    SURFF = SimpleKeyword("surff")

--- a/src/opi/input/simple_keywords/force_field.py
+++ b/src/opi/input/simple_keywords/force_field.py
@@ -7,15 +7,9 @@ __all__ = ("ForceField",)
 
 
 class ForceField(SimpleKeywordBox):
-    """Enum to store all simple keywords of type ForceField.
-
-    Attributes
-    ----------
-    GFN_FF : SimpleKeyword
-        GFN-FF (external) alias is xtb-ff
-    MM : SimpleKeyword
-        Use external molecular mechanics
-    """
+    """Enum to store all simple keywords of type ForceField."""
 
     GFN_FF = SimpleKeyword("gfn-ff")
+    """SimpleKeyword: GFN-FF (external) alias is xtb-ff."""
     MM = SimpleKeyword("mm")
+    """SimpleKeyword: Use external molecular mechanics."""

--- a/src/opi/input/simple_keywords/gcp.py
+++ b/src/opi/input/simple_keywords/gcp.py
@@ -59,72 +59,26 @@ class Gcp(SimpleKeywordBox):
         Correction for basis set errors (Method/basis set dependent)
     """
 
-    GCP_DFT_631G_D = SimpleKeyword(
-        "gcp(dft/631g(d))"
-    )
-    GCP_DFT_631GSTAR = SimpleKeyword(
-        "gcp(dft/631g*)"
-    )
-    GCP_DFT_631GD = SimpleKeyword(
-        "gcp(dft/631gd)"
-    )
-    GCP_DFT_LANL = SimpleKeyword(
-        "gcp(dft/lanl)"
-    )
-    GCP_DFT_MINIS = SimpleKeyword(
-        "gcp(dft/minis)"
-    )
-    GCP_DFT_SV_P = SimpleKeyword(
-        "gcp(dft/sv(p))"
-    )
-    GCP_DFT_SV_P_H_C = SimpleKeyword(
-        "gcp(dft/sv(p/h,c))"
-    )
-    GCP_DFT_SV = SimpleKeyword(
-        "gcp(dft/sv)"
-    )
-    GCP_DFT_SVP = SimpleKeyword(
-        "gcp(dft/svp)"
-    )
-    GCP_DFT_SVX = SimpleKeyword(
-        "gcp(dft/svx)"
-    )
-    GCP_DFT_TZ = SimpleKeyword(
-        "gcp(dft/tz)"
-    )
-    GCP_FILE = SimpleKeyword(
-        "gcp(file)"
-    )
-    GCP_HF_631G_D = SimpleKeyword(
-        "gcp(hf/631g(d))"
-    )
-    GCP_HF_631GSTAR = SimpleKeyword(
-        "gcp(hf/631g*)"
-    )
-    GCP_HF_631GD = SimpleKeyword(
-        "gcp(hf/631gd)"
-    )
-    GCP_HF_MINIS = SimpleKeyword(
-        "gcp(hf/minis)"
-    )
-    GCP_HF_MINIX = SimpleKeyword(
-        "gcp(hf/minix)"
-    )
-    GCP_HF_SV_P = SimpleKeyword(
-        "gcp(hf/sv(p))"
-    )
-    GCP_HF_SV_P_H_C = SimpleKeyword(
-        "gcp(hf/sv(p/h,c))"
-    )
-    GCP_HF_SV = SimpleKeyword(
-        "gcp(hf/sv)"
-    )
-    GCP_HF_SVP = SimpleKeyword(
-        "gcp(hf/svp)"
-    )
-    GCP_HF_SVX = SimpleKeyword(
-        "gcp(hf/svx)"
-    )
-    GCP_HF_TZ = SimpleKeyword(
-        "gcp(hf/tz)"
-    )
+    GCP_DFT_631G_D = SimpleKeyword("gcp(dft/631g(d))")
+    GCP_DFT_631GSTAR = SimpleKeyword("gcp(dft/631g*)")
+    GCP_DFT_631GD = SimpleKeyword("gcp(dft/631gd)")
+    GCP_DFT_LANL = SimpleKeyword("gcp(dft/lanl)")
+    GCP_DFT_MINIS = SimpleKeyword("gcp(dft/minis)")
+    GCP_DFT_SV_P = SimpleKeyword("gcp(dft/sv(p))")
+    GCP_DFT_SV_P_H_C = SimpleKeyword("gcp(dft/sv(p/h,c))")
+    GCP_DFT_SV = SimpleKeyword("gcp(dft/sv)")
+    GCP_DFT_SVP = SimpleKeyword("gcp(dft/svp)")
+    GCP_DFT_SVX = SimpleKeyword("gcp(dft/svx)")
+    GCP_DFT_TZ = SimpleKeyword("gcp(dft/tz)")
+    GCP_FILE = SimpleKeyword("gcp(file)")
+    GCP_HF_631G_D = SimpleKeyword("gcp(hf/631g(d))")
+    GCP_HF_631GSTAR = SimpleKeyword("gcp(hf/631g*)")
+    GCP_HF_631GD = SimpleKeyword("gcp(hf/631gd)")
+    GCP_HF_MINIS = SimpleKeyword("gcp(hf/minis)")
+    GCP_HF_MINIX = SimpleKeyword("gcp(hf/minix)")
+    GCP_HF_SV_P = SimpleKeyword("gcp(hf/sv(p))")
+    GCP_HF_SV_P_H_C = SimpleKeyword("gcp(hf/sv(p/h,c))")
+    GCP_HF_SV = SimpleKeyword("gcp(hf/sv)")
+    GCP_HF_SVP = SimpleKeyword("gcp(hf/svp)")
+    GCP_HF_SVX = SimpleKeyword("gcp(hf/svx)")
+    GCP_HF_TZ = SimpleKeyword("gcp(hf/tz)")

--- a/src/opi/input/simple_keywords/gcp.py
+++ b/src/opi/input/simple_keywords/gcp.py
@@ -7,78 +7,51 @@ __all__ = ("Gcp",)
 
 
 class Gcp(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Gcp.
-
-    Attributes
-    ----------
-    GCP_DFT_631G_D : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_DFT_631GSTAR : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_DFT_631GD : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_DFT_LANL : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_DFT_MINIS : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_DFT_SV_P : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_DFT_SV_P_H_C : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_DFT_SV : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_DFT_SVP : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_DFT_SVX : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_DFT_TZ : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_FILE : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_HF_631G_D : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_HF_631GSTAR : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_HF_631GD : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_HF_MINIS : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_HF_MINIX : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_HF_SV_P : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_HF_SV_P_H_C : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_HF_SV : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_HF_SVP : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_HF_SVX : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    GCP_HF_TZ : SimpleKeyword
-        Correction for basis set errors (Method/basis set dependent)
-    """
+    """Enum to store all simple keywords of type Gcp."""
 
     GCP_DFT_631G_D = SimpleKeyword("gcp(dft/631g(d))")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_DFT_631GSTAR = SimpleKeyword("gcp(dft/631g*)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_DFT_631GD = SimpleKeyword("gcp(dft/631gd)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_DFT_LANL = SimpleKeyword("gcp(dft/lanl)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_DFT_MINIS = SimpleKeyword("gcp(dft/minis)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_DFT_SV_P = SimpleKeyword("gcp(dft/sv(p))")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_DFT_SV_P_H_C = SimpleKeyword("gcp(dft/sv(p/h,c))")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_DFT_SV = SimpleKeyword("gcp(dft/sv)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_DFT_SVP = SimpleKeyword("gcp(dft/svp)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_DFT_SVX = SimpleKeyword("gcp(dft/svx)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_DFT_TZ = SimpleKeyword("gcp(dft/tz)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_FILE = SimpleKeyword("gcp(file)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_HF_631G_D = SimpleKeyword("gcp(hf/631g(d))")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_HF_631GSTAR = SimpleKeyword("gcp(hf/631g*)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_HF_631GD = SimpleKeyword("gcp(hf/631gd)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_HF_MINIS = SimpleKeyword("gcp(hf/minis)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_HF_MINIX = SimpleKeyword("gcp(hf/minix)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_HF_SV_P = SimpleKeyword("gcp(hf/sv(p))")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_HF_SV_P_H_C = SimpleKeyword("gcp(hf/sv(p/h,c))")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_HF_SV = SimpleKeyword("gcp(hf/sv)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_HF_SVP = SimpleKeyword("gcp(hf/svp)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_HF_SVX = SimpleKeyword("gcp(hf/svx)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""
     GCP_HF_TZ = SimpleKeyword("gcp(hf/tz)")
+    """SimpleKeyword: Correction for basis set errors (Method/basis set dependent)."""

--- a/src/opi/input/simple_keywords/gcp.py
+++ b/src/opi/input/simple_keywords/gcp.py
@@ -7,74 +7,124 @@ __all__ = ("Gcp",)
 
 
 class Gcp(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Gcp"""
+    """Enum to store all simple keywords of type Gcp.
+
+    Attributes
+    ----------
+    GCP_DFT_631G_D : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_DFT_631GSTAR : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_DFT_631GD : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_DFT_LANL : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_DFT_MINIS : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_DFT_SV_P : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_DFT_SV_P_H_C : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_DFT_SV : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_DFT_SVP : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_DFT_SVX : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_DFT_TZ : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_FILE : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_HF_631G_D : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_HF_631GSTAR : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_HF_631GD : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_HF_MINIS : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_HF_MINIX : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_HF_SV_P : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_HF_SV_P_H_C : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_HF_SV : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_HF_SVP : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_HF_SVX : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    GCP_HF_TZ : SimpleKeyword
+        Correction for basis set errors (Method/basis set dependent)
+    """
 
     GCP_DFT_631G_D = SimpleKeyword(
         "gcp(dft/631g(d))"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_DFT_631GSTAR = SimpleKeyword(
         "gcp(dft/631g*)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_DFT_631GD = SimpleKeyword(
         "gcp(dft/631gd)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_DFT_LANL = SimpleKeyword(
         "gcp(dft/lanl)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_DFT_MINIS = SimpleKeyword(
         "gcp(dft/minis)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_DFT_SV_P = SimpleKeyword(
         "gcp(dft/sv(p))"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_DFT_SV_P_H_C = SimpleKeyword(
         "gcp(dft/sv(p/h,c))"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_DFT_SV = SimpleKeyword(
         "gcp(dft/sv)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_DFT_SVP = SimpleKeyword(
         "gcp(dft/svp)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_DFT_SVX = SimpleKeyword(
         "gcp(dft/svx)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_DFT_TZ = SimpleKeyword(
         "gcp(dft/tz)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_FILE = SimpleKeyword(
         "gcp(file)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_HF_631G_D = SimpleKeyword(
         "gcp(hf/631g(d))"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_HF_631GSTAR = SimpleKeyword(
         "gcp(hf/631g*)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_HF_631GD = SimpleKeyword(
         "gcp(hf/631gd)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_HF_MINIS = SimpleKeyword(
         "gcp(hf/minis)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_HF_MINIX = SimpleKeyword(
         "gcp(hf/minix)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_HF_SV_P = SimpleKeyword(
         "gcp(hf/sv(p))"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_HF_SV_P_H_C = SimpleKeyword(
         "gcp(hf/sv(p/h,c))"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_HF_SV = SimpleKeyword(
         "gcp(hf/sv)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_HF_SVP = SimpleKeyword(
         "gcp(hf/svp)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_HF_SVX = SimpleKeyword(
         "gcp(hf/svx)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )
     GCP_HF_TZ = SimpleKeyword(
         "gcp(hf/tz)"
-    )  # Correction for basis set errors (Method/basis set dependent)
+    )

--- a/src/opi/input/simple_keywords/goat.py
+++ b/src/opi/input/simple_keywords/goat.py
@@ -7,12 +7,30 @@ __all__ = ("Goat",)
 
 
 class Goat(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Goat"""
+    """Enum to store all simple keywords of type Goat.
 
-    GOAT = SimpleKeyword("goat")  # GOAT Methods
-    GOAT_COARSE = SimpleKeyword("goat-coarse")  # GOAT Methods
-    GOAT_DIVERSITY = SimpleKeyword("goat-diversity")  # GOAT Methods
-    GOAT_ENTROPY = SimpleKeyword("goat-entropy")  # GOAT Methods
-    GOAT_EXPLORE = SimpleKeyword("goat-explore")  # GOAT Methods
-    GOAT_REACT = SimpleKeyword("goat-react")  # GOAT Methods
-    GOAT_TS = SimpleKeyword("goat-ts")  # GOAT Methods
+    Attributes
+    ----------
+    GOAT : SimpleKeyword
+        GOAT Methods
+    GOAT_COARSE : SimpleKeyword
+        GOAT Methods
+    GOAT_DIVERSITY : SimpleKeyword
+        GOAT Methods
+    GOAT_ENTROPY : SimpleKeyword
+        GOAT Methods
+    GOAT_EXPLORE : SimpleKeyword
+        GOAT Methods
+    GOAT_REACT : SimpleKeyword
+        GOAT Methods
+    GOAT_TS : SimpleKeyword
+        GOAT Methods
+    """
+
+    GOAT = SimpleKeyword("goat")
+    GOAT_COARSE = SimpleKeyword("goat-coarse")
+    GOAT_DIVERSITY = SimpleKeyword("goat-diversity")
+    GOAT_ENTROPY = SimpleKeyword("goat-entropy")
+    GOAT_EXPLORE = SimpleKeyword("goat-explore")
+    GOAT_REACT = SimpleKeyword("goat-react")
+    GOAT_TS = SimpleKeyword("goat-ts")

--- a/src/opi/input/simple_keywords/goat.py
+++ b/src/opi/input/simple_keywords/goat.py
@@ -7,30 +7,19 @@ __all__ = ("Goat",)
 
 
 class Goat(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Goat.
-
-    Attributes
-    ----------
-    GOAT : SimpleKeyword
-        GOAT Methods
-    GOAT_COARSE : SimpleKeyword
-        GOAT Methods
-    GOAT_DIVERSITY : SimpleKeyword
-        GOAT Methods
-    GOAT_ENTROPY : SimpleKeyword
-        GOAT Methods
-    GOAT_EXPLORE : SimpleKeyword
-        GOAT Methods
-    GOAT_REACT : SimpleKeyword
-        GOAT Methods
-    GOAT_TS : SimpleKeyword
-        GOAT Methods
-    """
+    """Enum to store all simple keywords of type Goat."""
 
     GOAT = SimpleKeyword("goat")
+    """SimpleKeyword: GOAT Methods."""
     GOAT_COARSE = SimpleKeyword("goat-coarse")
+    """SimpleKeyword: GOAT Methods."""
     GOAT_DIVERSITY = SimpleKeyword("goat-diversity")
+    """SimpleKeyword: GOAT Methods."""
     GOAT_ENTROPY = SimpleKeyword("goat-entropy")
+    """SimpleKeyword: GOAT Methods."""
     GOAT_EXPLORE = SimpleKeyword("goat-explore")
+    """SimpleKeyword: GOAT Methods."""
     GOAT_REACT = SimpleKeyword("goat-react")
+    """SimpleKeyword: GOAT Methods."""
     GOAT_TS = SimpleKeyword("goat-ts")
+    """SimpleKeyword: GOAT Methods."""

--- a/src/opi/input/simple_keywords/grid.py
+++ b/src/opi/input/simple_keywords/grid.py
@@ -7,10 +7,24 @@ __all__ = ("Grid",)
 
 
 class Grid(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Grid"""
+    """Enum to store all simple keywords of type Grid.
 
-    DEFGRID1 = SimpleKeyword("defgrid1")  # small grid
-    DEFGRID2 = SimpleKeyword("defgrid2")  # medium grid
-    DEFGRID3 = SimpleKeyword("defgrid3")  # large grid
-    REFGRID = SimpleKeyword("refgrid")  # reference grid
-    ROTINVGRID = SimpleKeyword("rotinvgrid")  # Rotational invariant grid
+    Attributes
+    ----------
+    DEFGRID1 : SimpleKeyword
+        small grid
+    DEFGRID2 : SimpleKeyword
+        medium grid
+    DEFGRID3 : SimpleKeyword
+        large grid
+    REFGRID : SimpleKeyword
+        reference grid
+    ROTINVGRID : SimpleKeyword
+        Rotational invariant grid
+    """
+
+    DEFGRID1 = SimpleKeyword("defgrid1")
+    DEFGRID2 = SimpleKeyword("defgrid2")
+    DEFGRID3 = SimpleKeyword("defgrid3")
+    REFGRID = SimpleKeyword("refgrid")
+    ROTINVGRID = SimpleKeyword("rotinvgrid")

--- a/src/opi/input/simple_keywords/grid.py
+++ b/src/opi/input/simple_keywords/grid.py
@@ -7,24 +7,15 @@ __all__ = ("Grid",)
 
 
 class Grid(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Grid.
-
-    Attributes
-    ----------
-    DEFGRID1 : SimpleKeyword
-        small grid
-    DEFGRID2 : SimpleKeyword
-        medium grid
-    DEFGRID3 : SimpleKeyword
-        large grid
-    REFGRID : SimpleKeyword
-        reference grid
-    ROTINVGRID : SimpleKeyword
-        Rotational invariant grid
-    """
+    """Enum to store all simple keywords of type Grid."""
 
     DEFGRID1 = SimpleKeyword("defgrid1")
+    """SimpleKeyword: small grid."""
     DEFGRID2 = SimpleKeyword("defgrid2")
+    """SimpleKeyword: medium grid."""
     DEFGRID3 = SimpleKeyword("defgrid3")
+    """SimpleKeyword: large grid."""
     REFGRID = SimpleKeyword("refgrid")
+    """SimpleKeyword: reference grid."""
     ROTINVGRID = SimpleKeyword("rotinvgrid")
+    """SimpleKeyword: Rotational invariant grid."""

--- a/src/opi/input/simple_keywords/method.py
+++ b/src/opi/input/simple_keywords/method.py
@@ -7,15 +7,9 @@ __all__ = ("Method",)
 
 
 class Method(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Method.
-
-    Attributes
-    ----------
-    HF : SimpleKeyword
-        Hartee-Fock
-    HF_3C : SimpleKeyword
-        3c methods, do not require dispersion correction or basis set
-    """
+    """Enum to store all simple keywords of type Method."""
 
     HF = SimpleKeyword("hf")
+    """SimpleKeyword: Hartee-Fock."""
     HF_3C = SimpleKeyword("hf-3c")
+    """SimpleKeyword: 3c methods, do not require dispersion correction or basis set."""

--- a/src/opi/input/simple_keywords/method.py
+++ b/src/opi/input/simple_keywords/method.py
@@ -7,7 +7,15 @@ __all__ = ("Method",)
 
 
 class Method(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Method"""
+    """Enum to store all simple keywords of type Method.
 
-    HF = SimpleKeyword("hf")  # Hartee-Fock
-    HF_3C = SimpleKeyword("hf-3c")  # 3c methods, do not require dispersion correction or basis set
+    Attributes
+    ----------
+    HF : SimpleKeyword
+        Hartee-Fock
+    HF_3C : SimpleKeyword
+        3c methods, do not require dispersion correction or basis set
+    """
+
+    HF = SimpleKeyword("hf")
+    HF_3C = SimpleKeyword("hf-3c")

--- a/src/opi/input/simple_keywords/miscellaneous.py
+++ b/src/opi/input/simple_keywords/miscellaneous.py
@@ -7,207 +7,137 @@ __all__ = ("Miscellaneous",)
 
 
 class Miscellaneous(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Miscellaneous.
-
-    Attributes
-    ----------
-    ANGS : SimpleKeyword
-        Miscellaneous
-    BOHRS : SimpleKeyword
-        Miscellaneous
-    CHEAPINTS : SimpleKeyword
-        Miscellaneous
-    KEEPDENS : SimpleKeyword
-        Miscellaneous
-    KEEPDENSITY : SimpleKeyword
-        Miscellaneous
-    KEEPFOCK : SimpleKeyword
-        Miscellaneous
-    KEEPINTS : SimpleKeyword
-        Miscellaneous
-    KEEPRESPDENSITY : SimpleKeyword
-        Miscellaneous
-    KEEPTRANSDENSITY : SimpleKeyword
-        Miscellaneous
-    LIBINT : SimpleKeyword
-        Libint for Integral generation
-    MASS2016 : SimpleKeyword
-        Miscellaneous
-    NOCHEAPINTS : SimpleKeyword
-        Miscellaneous
-    NOKEEPDENS : SimpleKeyword
-        Miscellaneous
-    NOKEEPDENSITY : SimpleKeyword
-        Miscellaneous
-    NOKEEPFOCK : SimpleKeyword
-        Miscellaneous
-    NOKEEPINTS : SimpleKeyword
-        Miscellaneous
-    NOLIBINT : SimpleKeyword
-        Libint for Integral generation
-    NOREADINTS : SimpleKeyword
-        Miscellaneous
-    NOSHARK : SimpleKeyword
-        Shark for integral generation
-    NOSYM : SimpleKeyword
-        Symmetry keywords
-    NOSYMMETRY : SimpleKeyword
-        Symmetry keywords
-    NOUSESHARK : SimpleKeyword
-        Shark for integral generation
-    NOUSESYM : SimpleKeyword
-        Symmetry keywords
-    NOUSESYMMETRY : SimpleKeyword
-        Symmetry keywords
-    NOXCFUN : SimpleKeyword
-        do not use Xcfun library
-    PAL : SimpleKeyword
-        Parallelization
-    PAL16 : SimpleKeyword
-        Parallelization
-    PAL16_4X4 : SimpleKeyword
-        Parallelization
-    PAL2 : SimpleKeyword
-        Parallelization
-    PAL3 : SimpleKeyword
-        Parallelization
-    PAL32 : SimpleKeyword
-        Parallelization
-    PAL32_4X8 : SimpleKeyword
-        Parallelization
-    PAL32_8X4 : SimpleKeyword
-        Parallelization
-    PAL4 : SimpleKeyword
-        Parallelization
-    PAL4_2X2 : SimpleKeyword
-        Parallelization
-    PAL5 : SimpleKeyword
-        Parallelization
-    PAL6 : SimpleKeyword
-        Parallelization
-    PAL64 : SimpleKeyword
-        Parallelization
-    PAL64_8X8 : SimpleKeyword
-        Parallelization
-    PAL7 : SimpleKeyword
-        Parallelization
-    PAL8 : SimpleKeyword
-        Parallelization
-    PAL8_2X4 : SimpleKeyword
-        Parallelization
-    PAL8_4X2 : SimpleKeyword
-        Parallelization
-    PREFERC2V : SimpleKeyword
-        Symmetry keywords
-    PREFERD2 : SimpleKeyword
-        Symmetry keywords
-    READINTS : SimpleKeyword
-        Miscellaneous
-    RESCUE : SimpleKeyword
-        Try to rescue a calculation from an old orca version
-    SCALEPC : SimpleKeyword
-        Scale Pointcharges
-    SHARK : SimpleKeyword
-        Shark for integral generation
-    USEC2V : SimpleKeyword
-        Symmetry keywords
-    USED2 : SimpleKeyword
-        Symmetry keywords
-    USESHARK : SimpleKeyword
-        Shark for integral generation
-    USESYM : SimpleKeyword
-        Symmetry keywords
-    USESYMMETRY : SimpleKeyword
-        Symmetry keywords
-    XCFUN : SimpleKeyword
-        Use Xcfun library
-    PAF : SimpleKeyword
-        Bring molecule into its principle axis orientation
-    ALLOWRHF : SimpleKeyword
-        AllowRHF for open-shell
-    NOALLOWRHF : SimpleKeyword
-        AllowRHF for open-shell
-    DOEQ : SimpleKeyword
-        Do Eq for nuclear charges
-    NOEQ : SimpleKeyword
-        Do not Eq for nuclear charges
-    BPOP : SimpleKeyword
-        Use Boltzmann weighting in multiple xyz job
-    NUMGRAD : SimpleKeyword
-        Numerical gradient
-    SURFCROSSNUMFREQ : SimpleKeyword
-        Check for surface crossing frequency
-    MECP_NUMFREQ : SimpleKeyword
-        Numerical MECP freq
-    NEARIR : SimpleKeyword
-        VPT2 analysis for nearIR
-    VPT2 : SimpleKeyword
-        VPT2 analysis
-    """
+    """Enum to store all simple keywords of type Miscellaneous."""
 
     ANGS = SimpleKeyword("angs")
+    """SimpleKeyword: Miscellaneous."""
     BOHRS = SimpleKeyword("bohrs")
+    """SimpleKeyword: Miscellaneous."""
     CHEAPINTS = SimpleKeyword("cheapints")
+    """SimpleKeyword: Miscellaneous."""
     KEEPDENS = SimpleKeyword("keepdens")
+    """SimpleKeyword: Miscellaneous."""
     KEEPDENSITY = SimpleKeyword("keepdensity")
+    """SimpleKeyword: Miscellaneous."""
     KEEPFOCK = SimpleKeyword("keepfock")
+    """SimpleKeyword: Miscellaneous."""
     KEEPINTS = SimpleKeyword("keepints")
+    """SimpleKeyword: Miscellaneous."""
     KEEPRESPDENSITY = SimpleKeyword("keeprespdensity")
+    """SimpleKeyword: Miscellaneous."""
     KEEPTRANSDENSITY = SimpleKeyword("keeptransdensity")
+    """SimpleKeyword: Miscellaneous."""
     LIBINT = SimpleKeyword("libint")
+    """SimpleKeyword: Libint for Integral generation."""
     MASS2016 = SimpleKeyword("mass2016")
+    """SimpleKeyword: Miscellaneous."""
     NOCHEAPINTS = SimpleKeyword("nocheapints")
+    """SimpleKeyword: Miscellaneous."""
     NOKEEPDENS = SimpleKeyword("nokeepdens")
+    """SimpleKeyword: Miscellaneous."""
     NOKEEPDENSITY = SimpleKeyword("nokeepdensity")
+    """SimpleKeyword: Miscellaneous."""
     NOKEEPFOCK = SimpleKeyword("nokeepfock")
+    """SimpleKeyword: Miscellaneous."""
     NOKEEPINTS = SimpleKeyword("nokeepints")
+    """SimpleKeyword: Miscellaneous."""
     NOLIBINT = SimpleKeyword("nolibint")
+    """SimpleKeyword: Libint for Integral generation."""
     NOREADINTS = SimpleKeyword("noreadints")
+    """SimpleKeyword: Miscellaneous."""
     NOSHARK = SimpleKeyword("noshark")
+    """SimpleKeyword: Shark for integral generation."""
     NOSYM = SimpleKeyword("nosym")
+    """SimpleKeyword: Symmetry keywords."""
     NOSYMMETRY = SimpleKeyword("nosymmetry")
+    """SimpleKeyword: Symmetry keywords."""
     NOUSESHARK = SimpleKeyword("nouseshark")
+    """SimpleKeyword: Shark for integral generation."""
     NOUSESYM = SimpleKeyword("nousesym")
+    """SimpleKeyword: Symmetry keywords."""
     NOUSESYMMETRY = SimpleKeyword("nousesymmetry")
+    """SimpleKeyword: Symmetry keywords."""
     NOXCFUN = SimpleKeyword("noxcfun")
+    """SimpleKeyword: do not use Xcfun library."""
     PAL = SimpleKeyword("pal")
+    """SimpleKeyword: Parallelization."""
     PAL16 = SimpleKeyword("pal16")
+    """SimpleKeyword: Parallelization."""
     PAL16_4X4 = SimpleKeyword("pal16(4x4)")
+    """SimpleKeyword: Parallelization."""
     PAL2 = SimpleKeyword("pal2")
+    """SimpleKeyword: Parallelization."""
     PAL3 = SimpleKeyword("pal3")
+    """SimpleKeyword: Parallelization."""
     PAL32 = SimpleKeyword("pal32")
+    """SimpleKeyword: Parallelization."""
     PAL32_4X8 = SimpleKeyword("pal32(4x8)")
+    """SimpleKeyword: Parallelization."""
     PAL32_8X4 = SimpleKeyword("pal32(8x4)")
+    """SimpleKeyword: Parallelization."""
     PAL4 = SimpleKeyword("pal4")
+    """SimpleKeyword: Parallelization."""
     PAL4_2X2 = SimpleKeyword("pal4(2x2)")
+    """SimpleKeyword: Parallelization."""
     PAL5 = SimpleKeyword("pal5")
+    """SimpleKeyword: Parallelization."""
     PAL6 = SimpleKeyword("pal6")
+    """SimpleKeyword: Parallelization."""
     PAL64 = SimpleKeyword("pal64")
+    """SimpleKeyword: Parallelization."""
     PAL64_8X8 = SimpleKeyword("pal64(8x8)")
+    """SimpleKeyword: Parallelization."""
     PAL7 = SimpleKeyword("pal7")
+    """SimpleKeyword: Parallelization."""
     PAL8 = SimpleKeyword("pal8")
+    """SimpleKeyword: Parallelization."""
     PAL8_2X4 = SimpleKeyword("pal8(2x4)")
+    """SimpleKeyword: Parallelization."""
     PAL8_4X2 = SimpleKeyword("pal8(4x2)")
+    """SimpleKeyword: Parallelization."""
     PREFERC2V = SimpleKeyword("preferc2v")
+    """SimpleKeyword: Symmetry keywords."""
     PREFERD2 = SimpleKeyword("preferd2")
+    """SimpleKeyword: Symmetry keywords."""
     READINTS = SimpleKeyword("readints")
+    """SimpleKeyword: Miscellaneous."""
     RESCUE = SimpleKeyword("rescue")
+    """SimpleKeyword: Try to rescue a calculation from an old orca version."""
     SCALEPC = SimpleKeyword("scalepc")
+    """SimpleKeyword: Scale Pointcharges."""
     SHARK = SimpleKeyword("shark")
+    """SimpleKeyword: Shark for integral generation."""
     USEC2V = SimpleKeyword("usec2v")
+    """SimpleKeyword: Symmetry keywords."""
     USED2 = SimpleKeyword("used2")
+    """SimpleKeyword: Symmetry keywords."""
     USESHARK = SimpleKeyword("useshark")
+    """SimpleKeyword: Shark for integral generation."""
     USESYM = SimpleKeyword("usesym")
+    """SimpleKeyword: Symmetry keywords."""
     USESYMMETRY = SimpleKeyword("usesymmetry")
+    """SimpleKeyword: Symmetry keywords."""
     XCFUN = SimpleKeyword("xcfun")
+    """SimpleKeyword: Use Xcfun library."""
     PAF = SimpleKeyword("paf")
+    """SimpleKeyword: Bring molecule into its principle axis orientation."""
     ALLOWRHF = SimpleKeyword("allowrhf")
+    """SimpleKeyword: AllowRHF for open-shell."""
     NOALLOWRHF = SimpleKeyword("noallowrhf")
+    """SimpleKeyword: AllowRHF for open-shell."""
     DOEQ = SimpleKeyword("doeq")
+    """SimpleKeyword: Do Eq for nuclear charges."""
     NOEQ = SimpleKeyword("noeq")
+    """SimpleKeyword: Do not Eq for nuclear charges."""
     BPOP = SimpleKeyword("bpop")
+    """SimpleKeyword: Use Boltzmann weighting in multiple xyz job."""
     NUMGRAD = SimpleKeyword("numgrad")
+    """SimpleKeyword: Numerical gradient."""
     SURFCROSSNUMFREQ = SimpleKeyword("surfcrossnumfreq")
+    """SimpleKeyword: Check for surface crossing frequency."""
     MECP_NUMFREQ = SimpleKeyword("mecp-numfreq")
+    """SimpleKeyword: Numerical MECP freq."""
     NEARIR = SimpleKeyword("nearir")
+    """SimpleKeyword: VPT2 analysis for nearIR."""
     VPT2 = SimpleKeyword("vpt2")
+    """SimpleKeyword: VPT2 analysis."""

--- a/src/opi/input/simple_keywords/miscellaneous.py
+++ b/src/opi/input/simple_keywords/miscellaneous.py
@@ -15,8 +15,6 @@ class Miscellaneous(SimpleKeywordBox):
     """SimpleKeyword: Miscellaneous."""
     CHEAPINTS = SimpleKeyword("cheapints")
     """SimpleKeyword: Miscellaneous."""
-    KEEPDENS = SimpleKeyword("keepdens")
-    """SimpleKeyword: Miscellaneous."""
     KEEPDENSITY = SimpleKeyword("keepdensity")
     """SimpleKeyword: Miscellaneous."""
     KEEPFOCK = SimpleKeyword("keepfock")
@@ -32,8 +30,6 @@ class Miscellaneous(SimpleKeywordBox):
     MASS2016 = SimpleKeyword("mass2016")
     """SimpleKeyword: Miscellaneous."""
     NOCHEAPINTS = SimpleKeyword("nocheapints")
-    """SimpleKeyword: Miscellaneous."""
-    NOKEEPDENS = SimpleKeyword("nokeepdens")
     """SimpleKeyword: Miscellaneous."""
     NOKEEPDENSITY = SimpleKeyword("nokeepdensity")
     """SimpleKeyword: Miscellaneous."""
@@ -59,42 +55,6 @@ class Miscellaneous(SimpleKeywordBox):
     """SimpleKeyword: Symmetry keywords."""
     NOXCFUN = SimpleKeyword("noxcfun")
     """SimpleKeyword: do not use Xcfun library."""
-    PAL = SimpleKeyword("pal")
-    """SimpleKeyword: Parallelization."""
-    PAL16 = SimpleKeyword("pal16")
-    """SimpleKeyword: Parallelization."""
-    PAL16_4X4 = SimpleKeyword("pal16(4x4)")
-    """SimpleKeyword: Parallelization."""
-    PAL2 = SimpleKeyword("pal2")
-    """SimpleKeyword: Parallelization."""
-    PAL3 = SimpleKeyword("pal3")
-    """SimpleKeyword: Parallelization."""
-    PAL32 = SimpleKeyword("pal32")
-    """SimpleKeyword: Parallelization."""
-    PAL32_4X8 = SimpleKeyword("pal32(4x8)")
-    """SimpleKeyword: Parallelization."""
-    PAL32_8X4 = SimpleKeyword("pal32(8x4)")
-    """SimpleKeyword: Parallelization."""
-    PAL4 = SimpleKeyword("pal4")
-    """SimpleKeyword: Parallelization."""
-    PAL4_2X2 = SimpleKeyword("pal4(2x2)")
-    """SimpleKeyword: Parallelization."""
-    PAL5 = SimpleKeyword("pal5")
-    """SimpleKeyword: Parallelization."""
-    PAL6 = SimpleKeyword("pal6")
-    """SimpleKeyword: Parallelization."""
-    PAL64 = SimpleKeyword("pal64")
-    """SimpleKeyword: Parallelization."""
-    PAL64_8X8 = SimpleKeyword("pal64(8x8)")
-    """SimpleKeyword: Parallelization."""
-    PAL7 = SimpleKeyword("pal7")
-    """SimpleKeyword: Parallelization."""
-    PAL8 = SimpleKeyword("pal8")
-    """SimpleKeyword: Parallelization."""
-    PAL8_2X4 = SimpleKeyword("pal8(2x4)")
-    """SimpleKeyword: Parallelization."""
-    PAL8_4X2 = SimpleKeyword("pal8(4x2)")
-    """SimpleKeyword: Parallelization."""
     PREFERC2V = SimpleKeyword("preferc2v")
     """SimpleKeyword: Symmetry keywords."""
     PREFERD2 = SimpleKeyword("preferd2")

--- a/src/opi/input/simple_keywords/miscellaneous.py
+++ b/src/opi/input/simple_keywords/miscellaneous.py
@@ -7,7 +7,143 @@ __all__ = ("Miscellaneous",)
 
 
 class Miscellaneous(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Miscellaneous"""
+    """Enum to store all simple keywords of type Miscellaneous.
+
+    Attributes
+    ----------
+    ANGS : SimpleKeyword
+        Miscellaneous
+    BOHRS : SimpleKeyword
+        Miscellaneous
+    CHEAPINTS : SimpleKeyword
+        Miscellaneous
+    KEEPDENS : SimpleKeyword
+        Miscellaneous
+    KEEPDENSITY : SimpleKeyword
+        Miscellaneous
+    KEEPFOCK : SimpleKeyword
+        Miscellaneous
+    KEEPINTS : SimpleKeyword
+        Miscellaneous
+    KEEPRESPDENSITY : SimpleKeyword
+        Miscellaneous
+    KEEPTRANSDENSITY : SimpleKeyword
+        Miscellaneous
+    LIBINT : SimpleKeyword
+        Libint for Integral generation
+    MASS2016 : SimpleKeyword
+        Miscellaneous
+    NOCHEAPINTS : SimpleKeyword
+        Miscellaneous
+    NOKEEPDENS : SimpleKeyword
+        Miscellaneous
+    NOKEEPDENSITY : SimpleKeyword
+        Miscellaneous
+    NOKEEPFOCK : SimpleKeyword
+        Miscellaneous
+    NOKEEPINTS : SimpleKeyword
+        Miscellaneous
+    NOLIBINT : SimpleKeyword
+        Libint for Integral generation
+    NOREADINTS : SimpleKeyword
+        Miscellaneous
+    NOSHARK : SimpleKeyword
+        Shark for integral generation
+    NOSYM : SimpleKeyword
+        Symmetry keywords
+    NOSYMMETRY : SimpleKeyword
+        Symmetry keywords
+    NOUSESHARK : SimpleKeyword
+        Shark for integral generation
+    NOUSESYM : SimpleKeyword
+        Symmetry keywords
+    NOUSESYMMETRY : SimpleKeyword
+        Symmetry keywords
+    NOXCFUN : SimpleKeyword
+        do not use Xcfun library
+    PAL : SimpleKeyword
+        Parallelization
+    PAL16 : SimpleKeyword
+        Parallelization
+    PAL16_4X4 : SimpleKeyword
+        Parallelization
+    PAL2 : SimpleKeyword
+        Parallelization
+    PAL3 : SimpleKeyword
+        Parallelization
+    PAL32 : SimpleKeyword
+        Parallelization
+    PAL32_4X8 : SimpleKeyword
+        Parallelization
+    PAL32_8X4 : SimpleKeyword
+        Parallelization
+    PAL4 : SimpleKeyword
+        Parallelization
+    PAL4_2X2 : SimpleKeyword
+        Parallelization
+    PAL5 : SimpleKeyword
+        Parallelization
+    PAL6 : SimpleKeyword
+        Parallelization
+    PAL64 : SimpleKeyword
+        Parallelization
+    PAL64_8X8 : SimpleKeyword
+        Parallelization
+    PAL7 : SimpleKeyword
+        Parallelization
+    PAL8 : SimpleKeyword
+        Parallelization
+    PAL8_2X4 : SimpleKeyword
+        Parallelization
+    PAL8_4X2 : SimpleKeyword
+        Parallelization
+    PREFERC2V : SimpleKeyword
+        Symmetry keywords
+    PREFERD2 : SimpleKeyword
+        Symmetry keywords
+    READINTS : SimpleKeyword
+        Miscellaneous
+    RESCUE : SimpleKeyword
+        Try to rescue a calculation from an old orca version
+    SCALEPC : SimpleKeyword
+        Scale Pointcharges
+    SHARK : SimpleKeyword
+        Shark for integral generation
+    USEC2V : SimpleKeyword
+        Symmetry keywords
+    USED2 : SimpleKeyword
+        Symmetry keywords
+    USESHARK : SimpleKeyword
+        Shark for integral generation
+    USESYM : SimpleKeyword
+        Symmetry keywords
+    USESYMMETRY : SimpleKeyword
+        Symmetry keywords
+    XCFUN : SimpleKeyword
+        Use Xcfun library
+    PAF : SimpleKeyword
+        Bring molecule into its principle axis orientation
+    ALLOWRHF : SimpleKeyword
+        AllowRHF for open-shell
+    NOALLOWRHF : SimpleKeyword
+        AllowRHF for open-shell
+    DOEQ : SimpleKeyword
+        Do Eq for nuclear charges
+    NOEQ : SimpleKeyword
+        Do not Eq for nuclear charges
+    BPOP : SimpleKeyword
+        Use Boltzmann weighting in multiple xyz job
+    NUMGRAD : SimpleKeyword
+        Numerical gradient
+    SURFCROSSNUMFREQ : SimpleKeyword
+        Check for surface crossing frequency
+    MECP_NUMFREQ : SimpleKeyword
+        Numerical MECP freq
+    NEARIR : SimpleKeyword
+        VPT2 analysis for nearIR
+    VPT2 : SimpleKeyword
+        VPT2 analysis
+    """
 
     ANGS = SimpleKeyword("angs")
     BOHRS = SimpleKeyword("bohrs")
@@ -18,60 +154,60 @@ class Miscellaneous(SimpleKeywordBox):
     KEEPINTS = SimpleKeyword("keepints")
     KEEPRESPDENSITY = SimpleKeyword("keeprespdensity")
     KEEPTRANSDENSITY = SimpleKeyword("keeptransdensity")
-    LIBINT = SimpleKeyword("libint")  # Libint for Integral generation
+    LIBINT = SimpleKeyword("libint")
     MASS2016 = SimpleKeyword("mass2016")
     NOCHEAPINTS = SimpleKeyword("nocheapints")
     NOKEEPDENS = SimpleKeyword("nokeepdens")
     NOKEEPDENSITY = SimpleKeyword("nokeepdensity")
     NOKEEPFOCK = SimpleKeyword("nokeepfock")
     NOKEEPINTS = SimpleKeyword("nokeepints")
-    NOLIBINT = SimpleKeyword("nolibint")  # Libint for Integral generation
+    NOLIBINT = SimpleKeyword("nolibint")
     NOREADINTS = SimpleKeyword("noreadints")
-    NOSHARK = SimpleKeyword("noshark")  # Shark for integral generation
-    NOSYM = SimpleKeyword("nosym")  # Symmetry keywords
-    NOSYMMETRY = SimpleKeyword("nosymmetry")  # Symmetry keywords
-    NOUSESHARK = SimpleKeyword("nouseshark")  # Shark for integral generation
-    NOUSESYM = SimpleKeyword("nousesym")  # Symmetry keywords
-    NOUSESYMMETRY = SimpleKeyword("nousesymmetry")  # Symmetry keywords
-    NOXCFUN = SimpleKeyword("noxcfun")  # do not use Xcfun library
-    PAL = SimpleKeyword("pal")  # Parallelization
-    PAL16 = SimpleKeyword("pal16")  # Parallelization
-    PAL16_4X4 = SimpleKeyword("pal16(4x4)")  # Parallelization
-    PAL2 = SimpleKeyword("pal2")  # Parallelization
-    PAL3 = SimpleKeyword("pal3")  # Parallelization
-    PAL32 = SimpleKeyword("pal32")  # Parallelization
-    PAL32_4X8 = SimpleKeyword("pal32(4x8)")  # Parallelization
-    PAL32_8X4 = SimpleKeyword("pal32(8x4)")  # Parallelization
-    PAL4 = SimpleKeyword("pal4")  # Parallelization
-    PAL4_2X2 = SimpleKeyword("pal4(2x2)")  # Parallelization
-    PAL5 = SimpleKeyword("pal5")  # Parallelization
-    PAL6 = SimpleKeyword("pal6")  # Parallelization
-    PAL64 = SimpleKeyword("pal64")  # Parallelization
-    PAL64_8X8 = SimpleKeyword("pal64(8x8)")  # Parallelization
-    PAL7 = SimpleKeyword("pal7")  # Parallelization
-    PAL8 = SimpleKeyword("pal8")  # Parallelization
-    PAL8_2X4 = SimpleKeyword("pal8(2x4)")  # Parallelization
-    PAL8_4X2 = SimpleKeyword("pal8(4x2)")  # Parallelization
-    PREFERC2V = SimpleKeyword("preferc2v")  # Symmetry keywords
-    PREFERD2 = SimpleKeyword("preferd2")  # Symmetry keywords
+    NOSHARK = SimpleKeyword("noshark")
+    NOSYM = SimpleKeyword("nosym")
+    NOSYMMETRY = SimpleKeyword("nosymmetry")
+    NOUSESHARK = SimpleKeyword("nouseshark")
+    NOUSESYM = SimpleKeyword("nousesym")
+    NOUSESYMMETRY = SimpleKeyword("nousesymmetry")
+    NOXCFUN = SimpleKeyword("noxcfun")
+    PAL = SimpleKeyword("pal")
+    PAL16 = SimpleKeyword("pal16")
+    PAL16_4X4 = SimpleKeyword("pal16(4x4)")
+    PAL2 = SimpleKeyword("pal2")
+    PAL3 = SimpleKeyword("pal3")
+    PAL32 = SimpleKeyword("pal32")
+    PAL32_4X8 = SimpleKeyword("pal32(4x8)")
+    PAL32_8X4 = SimpleKeyword("pal32(8x4)")
+    PAL4 = SimpleKeyword("pal4")
+    PAL4_2X2 = SimpleKeyword("pal4(2x2)")
+    PAL5 = SimpleKeyword("pal5")
+    PAL6 = SimpleKeyword("pal6")
+    PAL64 = SimpleKeyword("pal64")
+    PAL64_8X8 = SimpleKeyword("pal64(8x8)")
+    PAL7 = SimpleKeyword("pal7")
+    PAL8 = SimpleKeyword("pal8")
+    PAL8_2X4 = SimpleKeyword("pal8(2x4)")
+    PAL8_4X2 = SimpleKeyword("pal8(4x2)")
+    PREFERC2V = SimpleKeyword("preferc2v")
+    PREFERD2 = SimpleKeyword("preferd2")
     READINTS = SimpleKeyword("readints")
-    RESCUE = SimpleKeyword("rescue")  # Try to rescue a calculation from an old orca version
-    SCALEPC = SimpleKeyword("scalepc")  # Scale Pointcharges
-    SHARK = SimpleKeyword("shark")  # Shark for integral generation
-    USEC2V = SimpleKeyword("usec2v")  # Symmetry keywords
-    USED2 = SimpleKeyword("used2")  # Symmetry keywords
-    USESHARK = SimpleKeyword("useshark")  # Shark for integral generation
-    USESYM = SimpleKeyword("usesym")  # Symmetry keywords
-    USESYMMETRY = SimpleKeyword("usesymmetry")  # Symmetry keywords
-    XCFUN = SimpleKeyword("xcfun")  # Use Xcfun library
-    PAF = SimpleKeyword("paf")  # Bring molecule into its principle axis orientation
-    ALLOWRHF = SimpleKeyword("allowrhf")  # AllowRHF for open-shell
-    NOALLOWRHF = SimpleKeyword("noallowrhf")  # AllowRHF for open-shell
-    DOEQ = SimpleKeyword("doeq")  # Do Eq for nuclear charges
-    NOEQ = SimpleKeyword("noeq")  # Do not Eq for nuclear charges
-    BPOP = SimpleKeyword("bpop")  # Use Boltzmann weighting in multiple xyz job
-    NUMGRAD = SimpleKeyword("numgrad")  # Numerical gradient
-    SURFCROSSNUMFREQ = SimpleKeyword("surfcrossnumfreq")  # Check for surface crossing frequency
-    MECP_NUMFREQ = SimpleKeyword("mecp-numfreq")  # Numerical MECP freq
-    NEARIR = SimpleKeyword("nearir")  # VPT2 analysis for nearIR
-    VPT2 = SimpleKeyword("vpt2")  # VPT2 analysis
+    RESCUE = SimpleKeyword("rescue")
+    SCALEPC = SimpleKeyword("scalepc")
+    SHARK = SimpleKeyword("shark")
+    USEC2V = SimpleKeyword("usec2v")
+    USED2 = SimpleKeyword("used2")
+    USESHARK = SimpleKeyword("useshark")
+    USESYM = SimpleKeyword("usesym")
+    USESYMMETRY = SimpleKeyword("usesymmetry")
+    XCFUN = SimpleKeyword("xcfun")
+    PAF = SimpleKeyword("paf")
+    ALLOWRHF = SimpleKeyword("allowrhf")
+    NOALLOWRHF = SimpleKeyword("noallowrhf")
+    DOEQ = SimpleKeyword("doeq")
+    NOEQ = SimpleKeyword("noeq")
+    BPOP = SimpleKeyword("bpop")
+    NUMGRAD = SimpleKeyword("numgrad")
+    SURFCROSSNUMFREQ = SimpleKeyword("surfcrossnumfreq")
+    MECP_NUMFREQ = SimpleKeyword("mecp-numfreq")
+    NEARIR = SimpleKeyword("nearir")
+    VPT2 = SimpleKeyword("vpt2")

--- a/src/opi/input/simple_keywords/neb.py
+++ b/src/opi/input/simple_keywords/neb.py
@@ -7,51 +7,33 @@ __all__ = ("Neb",)
 
 
 class Neb(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Neb.
-
-    Attributes
-    ----------
-    NEB : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    NEB_CI : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    NEB_IDPP : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    NEB_MMFTS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    FAST_NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    LOOSE_NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    TIGHT_NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB_CI : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    FLAT_NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    IRC : SimpleKeyword
-        internal reaction coordinate
-    SCANTS : SimpleKeyword
-        scan for transition state
-    """
+    """Enum to store all simple keywords of type Neb."""
 
     NEB = SimpleKeyword("neb")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     NEB_CI = SimpleKeyword("neb-ci")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     NEB_IDPP = SimpleKeyword("neb-idpp")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     NEB_MMFTS = SimpleKeyword("neb-mmfts")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     NEB_TS = SimpleKeyword("neb-ts")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     FAST_NEB_TS = SimpleKeyword("fast-neb-ts")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     LOOSE_NEB_TS = SimpleKeyword("loose-neb-ts")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     TIGHT_NEB_TS = SimpleKeyword("tight-neb-ts")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     ZOOM_NEB = SimpleKeyword("zoom-neb")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     ZOOM_NEB_CI = SimpleKeyword("zoom-neb-ci")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     ZOOM_NEB_TS = SimpleKeyword("zoom-neb-ts")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     FLAT_NEB_TS = SimpleKeyword("flat-neb-ts")
+    """SimpleKeyword: NEB for finding minimal energy pathways (and transition states)."""
     IRC = SimpleKeyword("irc")
+    """SimpleKeyword: internal reaction coordinate."""
     SCANTS = SimpleKeyword("scants")
+    """SimpleKeyword: scan for transition state."""

--- a/src/opi/input/simple_keywords/neb.py
+++ b/src/opi/input/simple_keywords/neb.py
@@ -7,41 +7,51 @@ __all__ = ("Neb",)
 
 
 class Neb(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Neb"""
+    """Enum to store all simple keywords of type Neb.
 
-    NEB = SimpleKeyword("neb")  # NEB for finding minimal energy pathways (and transition states)
-    NEB_CI = SimpleKeyword(
-        "neb-ci"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    NEB_IDPP = SimpleKeyword(
-        "neb-idpp"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    NEB_MMFTS = SimpleKeyword(
-        "neb-mmfts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    NEB_TS = SimpleKeyword(
-        "neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    FAST_NEB_TS = SimpleKeyword(
-        "fast-neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    LOOSE_NEB_TS = SimpleKeyword(
-        "loose-neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    TIGHT_NEB_TS = SimpleKeyword(
-        "tight-neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB = SimpleKeyword(
-        "zoom-neb"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB_CI = SimpleKeyword(
-        "zoom-neb-ci"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB_TS = SimpleKeyword(
-        "zoom-neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    FLAT_NEB_TS = SimpleKeyword(
-        "flat-neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    IRC = SimpleKeyword("irc")  # internal reaction coordinate
-    SCANTS = SimpleKeyword("scants")  # scan for transition state
+    Attributes
+    ----------
+    NEB : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    NEB_CI : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    NEB_IDPP : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    NEB_MMFTS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    FAST_NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    LOOSE_NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    TIGHT_NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    ZOOM_NEB : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    ZOOM_NEB_CI : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    ZOOM_NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    FLAT_NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    IRC : SimpleKeyword
+        internal reaction coordinate
+    SCANTS : SimpleKeyword
+        scan for transition state
+    """
+
+    NEB = SimpleKeyword("neb")
+    NEB_CI = SimpleKeyword("neb-ci")
+    NEB_IDPP = SimpleKeyword("neb-idpp")
+    NEB_MMFTS = SimpleKeyword("neb-mmfts")
+    NEB_TS = SimpleKeyword("neb-ts")
+    FAST_NEB_TS = SimpleKeyword("fast-neb-ts")
+    LOOSE_NEB_TS = SimpleKeyword("loose-neb-ts")
+    TIGHT_NEB_TS = SimpleKeyword("tight-neb-ts")
+    ZOOM_NEB = SimpleKeyword("zoom-neb")
+    ZOOM_NEB_CI = SimpleKeyword("zoom-neb-ci")
+    ZOOM_NEB_TS = SimpleKeyword("zoom-neb-ts")
+    FLAT_NEB_TS = SimpleKeyword("flat-neb-ts")
+    IRC = SimpleKeyword("irc")
+    SCANTS = SimpleKeyword("scants")

--- a/src/opi/input/simple_keywords/opt.py
+++ b/src/opi/input/simple_keywords/opt.py
@@ -12,7 +12,7 @@ class Opt(SimpleKeywordBox):
     Attributes
     ----------
     OPT : SimpleKeyword
-        Perform geometry optimization
+        Perform a geometry optimization
     CRUDEOPT : SimpleKeyword
         Geometry optimization with thresholds
     INTERPOPT : SimpleKeyword

--- a/src/opi/input/simple_keywords/opt.py
+++ b/src/opi/input/simple_keywords/opt.py
@@ -7,24 +7,66 @@ __all__ = ("Opt",)
 
 
 class Opt(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Opt"""
+    """Enum to store all simple keywords of type Opt.
 
-    OPT = SimpleKeyword("opt")  # Perform geometry optimization
-    CRUDEOPT = SimpleKeyword("crudeopt")  # Geometry optimization with thresholds
-    INTERPOPT = SimpleKeyword("interpopt")  # Geometry optimization with thresholds
-    LOOSEOPT = SimpleKeyword("looseopt")  # Geometry optimization with thresholds
-    NORMALOPT = SimpleKeyword("normalopt")  # Geometry optimization with thresholds
-    SLOPPYOPT = SimpleKeyword("sloppyopt")  # Geometry optimization with thresholds
-    TIGHTOPT = SimpleKeyword("tightopt")  # Geometry optimization with thresholds
-    VERYTIGHTOPT = SimpleKeyword("verytightopt")  # Geometry optimization with thresholds
-    OPTH = SimpleKeyword("opth")  # Optimize only hydrogen atoms
-    COPT = SimpleKeyword("copt")  # Perform geometry optimization (cartesian coordinates)
-    L_OPT = SimpleKeyword("l-opt")  # Perform geometry optimization
-    L_OPTH = SimpleKeyword("l-opth")  # Optimize only hydrogen atoms
-    OPTTS = SimpleKeyword("optts")  # optimize transition state
-    OPTTS_GMF = SimpleKeyword("optts(gmf)")  # optimize transition state
-    QMMMOPT = SimpleKeyword("qmmmopt")  # Optimize the geometry with qmmm
-    QMMMOPT_PDYNAMO = SimpleKeyword("qmmmopt/pdynamo")  # Optimize the geometry with qmmm
-    RIGIDBODYOPT = SimpleKeyword("rigidbodyopt")  # Optimize fragments as rigid bodies
-    CI_OPT = SimpleKeyword("ci-opt")  # conical-intersection optimization
-    MECP_OPT = SimpleKeyword("mecp-opt")  # MECP optimization
+    Attributes
+    ----------
+    OPT : SimpleKeyword
+        Perform geometry optimization
+    CRUDEOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    INTERPOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    LOOSEOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    NORMALOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    SLOPPYOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    TIGHTOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    VERYTIGHTOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    OPTH : SimpleKeyword
+        Optimize only hydrogen atoms
+    COPT : SimpleKeyword
+        Perform geometry optimization (cartesian coordinates)
+    L_OPT : SimpleKeyword
+        Perform geometry optimization
+    L_OPTH : SimpleKeyword
+        Optimize only hydrogen atoms
+    OPTTS : SimpleKeyword
+        optimize transition state
+    OPTTS_GMF : SimpleKeyword
+        optimize transition state
+    QMMMOPT : SimpleKeyword
+        Optimize the geometry with qmmm
+    QMMMOPT_PDYNAMO : SimpleKeyword
+        Optimize the geometry with qmmm
+    RIGIDBODYOPT : SimpleKeyword
+        Optimize fragments as rigid bodies
+    CI_OPT : SimpleKeyword
+        conical-intersection optimization
+    MECP_OPT : SimpleKeyword
+        MECP optimization
+    """
+
+    OPT = SimpleKeyword("opt")
+    CRUDEOPT = SimpleKeyword("crudeopt")
+    INTERPOPT = SimpleKeyword("interpopt")
+    LOOSEOPT = SimpleKeyword("looseopt")
+    NORMALOPT = SimpleKeyword("normalopt")
+    SLOPPYOPT = SimpleKeyword("sloppyopt")
+    TIGHTOPT = SimpleKeyword("tightopt")
+    VERYTIGHTOPT = SimpleKeyword("verytightopt")
+    OPTH = SimpleKeyword("opth")
+    COPT = SimpleKeyword("copt")
+    L_OPT = SimpleKeyword("l-opt")
+    L_OPTH = SimpleKeyword("l-opth")
+    OPTTS = SimpleKeyword("optts")
+    OPTTS_GMF = SimpleKeyword("optts(gmf)")
+    QMMMOPT = SimpleKeyword("qmmmopt")
+    QMMMOPT_PDYNAMO = SimpleKeyword("qmmmopt/pdynamo")
+    RIGIDBODYOPT = SimpleKeyword("rigidbodyopt")
+    CI_OPT = SimpleKeyword("ci-opt")
+    MECP_OPT = SimpleKeyword("mecp-opt")

--- a/src/opi/input/simple_keywords/opt.py
+++ b/src/opi/input/simple_keywords/opt.py
@@ -7,66 +7,43 @@ __all__ = ("Opt",)
 
 
 class Opt(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Opt.
-
-    Attributes
-    ----------
-    OPT : SimpleKeyword
-        Perform a geometry optimization
-    CRUDEOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    INTERPOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    LOOSEOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    NORMALOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    SLOPPYOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    TIGHTOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    VERYTIGHTOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    OPTH : SimpleKeyword
-        Optimize only hydrogen atoms
-    COPT : SimpleKeyword
-        Perform geometry optimization (cartesian coordinates)
-    L_OPT : SimpleKeyword
-        Perform geometry optimization
-    L_OPTH : SimpleKeyword
-        Optimize only hydrogen atoms
-    OPTTS : SimpleKeyword
-        optimize transition state
-    OPTTS_GMF : SimpleKeyword
-        optimize transition state
-    QMMMOPT : SimpleKeyword
-        Optimize the geometry with qmmm
-    QMMMOPT_PDYNAMO : SimpleKeyword
-        Optimize the geometry with qmmm
-    RIGIDBODYOPT : SimpleKeyword
-        Optimize fragments as rigid bodies
-    CI_OPT : SimpleKeyword
-        conical-intersection optimization
-    MECP_OPT : SimpleKeyword
-        MECP optimization
-    """
+    """Enum to store all simple keywords of type Opt."""
 
     OPT = SimpleKeyword("opt")
+    """SimpleKeyword: Perform a geometry optimization."""
     CRUDEOPT = SimpleKeyword("crudeopt")
+    """SimpleKeyword: Geometry optimization with thresholds."""
     INTERPOPT = SimpleKeyword("interpopt")
+    """SimpleKeyword: Geometry optimization with thresholds."""
     LOOSEOPT = SimpleKeyword("looseopt")
+    """SimpleKeyword: Geometry optimization with thresholds."""
     NORMALOPT = SimpleKeyword("normalopt")
+    """SimpleKeyword: Geometry optimization with thresholds."""
     SLOPPYOPT = SimpleKeyword("sloppyopt")
+    """SimpleKeyword: Geometry optimization with thresholds."""
     TIGHTOPT = SimpleKeyword("tightopt")
+    """SimpleKeyword: Geometry optimization with thresholds."""
     VERYTIGHTOPT = SimpleKeyword("verytightopt")
+    """SimpleKeyword: Geometry optimization with thresholds."""
     OPTH = SimpleKeyword("opth")
+    """SimpleKeyword: Optimize only hydrogen atoms."""
     COPT = SimpleKeyword("copt")
+    """SimpleKeyword: Perform geometry optimization (cartesian coordinates)."""
     L_OPT = SimpleKeyword("l-opt")
+    """SimpleKeyword: Perform geometry optimization."""
     L_OPTH = SimpleKeyword("l-opth")
+    """SimpleKeyword: Optimize only hydrogen atoms."""
     OPTTS = SimpleKeyword("optts")
+    """SimpleKeyword: optimize transition state."""
     OPTTS_GMF = SimpleKeyword("optts(gmf)")
+    """SimpleKeyword: optimize transition state."""
     QMMMOPT = SimpleKeyword("qmmmopt")
+    """SimpleKeyword: Optimize the geometry with qmmm."""
     QMMMOPT_PDYNAMO = SimpleKeyword("qmmmopt/pdynamo")
+    """SimpleKeyword: Optimize the geometry with qmmm."""
     RIGIDBODYOPT = SimpleKeyword("rigidbodyopt")
+    """SimpleKeyword: Optimize fragments as rigid bodies."""
     CI_OPT = SimpleKeyword("ci-opt")
+    """SimpleKeyword: conical-intersection optimization."""
     MECP_OPT = SimpleKeyword("mecp-opt")
+    """SimpleKeyword: MECP optimization."""

--- a/src/opi/input/simple_keywords/output_control.py
+++ b/src/opi/input/simple_keywords/output_control.py
@@ -7,7 +7,37 @@ __all__ = ("OutputControl",)
 
 
 class OutputControl(SimpleKeywordBox):
-    """Enum to store all simple keywords of type OutputControl"""
+    """Enum to store all simple keywords of type OutputControl.
+
+    Attributes
+    ----------
+    MINIPRINT : SimpleKeyword
+        OutputControl
+    SMALLPRINT : SimpleKeyword
+        OutputControl
+    NORMALPRINT : SimpleKeyword
+        OutputControl
+    LARGEPRINT : SimpleKeyword
+        OutputControl
+    SCFSOLVERTIME : SimpleKeyword
+        OutputControl
+    PRINTGAP : SimpleKeyword
+        OutputControl
+    PRINTMOS : SimpleKeyword
+        OutputControl
+    PRINTBASIS : SimpleKeyword
+        printbas
+    GRIDPRINT : SimpleKeyword
+        Print grid information
+    WRITEONLYINITIALPROPFILE : SimpleKeyword
+        Only write property file for first geometry
+    NOMOPRINT : SimpleKeyword
+        OutputControl
+    NOPROPFILE : SimpleKeyword
+        Write no property file
+    NOPRINTMOS : SimpleKeyword
+        OutputControl
+    """
 
     MINIPRINT = SimpleKeyword("miniprint")
     SMALLPRINT = SimpleKeyword("smallprint")
@@ -16,11 +46,9 @@ class OutputControl(SimpleKeywordBox):
     SCFSOLVERTIME = SimpleKeyword("scfsolvertime")
     PRINTGAP = SimpleKeyword("printgap")
     PRINTMOS = SimpleKeyword("printmos")
-    PRINTBASIS = SimpleKeyword("printbasis")  # printbas
-    GRIDPRINT = SimpleKeyword("gridprint")  # Print grid information
-    WRITEONLYINITIALPROPFILE = SimpleKeyword(
-        "writeonlyinitialpropfile"
-    )  # Only write property file for first geometry
+    PRINTBASIS = SimpleKeyword("printbasis")
+    GRIDPRINT = SimpleKeyword("gridprint")
+    WRITEONLYINITIALPROPFILE = SimpleKeyword("writeonlyinitialpropfile")
     NOMOPRINT = SimpleKeyword("nomoprint")
-    NOPROPFILE = SimpleKeyword("nopropfile")  # Write no property file
+    NOPROPFILE = SimpleKeyword("nopropfile")
     NOPRINTMOS = SimpleKeyword("noprintmos")

--- a/src/opi/input/simple_keywords/output_control.py
+++ b/src/opi/input/simple_keywords/output_control.py
@@ -7,48 +7,31 @@ __all__ = ("OutputControl",)
 
 
 class OutputControl(SimpleKeywordBox):
-    """Enum to store all simple keywords of type OutputControl.
-
-    Attributes
-    ----------
-    MINIPRINT : SimpleKeyword
-        OutputControl
-    SMALLPRINT : SimpleKeyword
-        OutputControl
-    NORMALPRINT : SimpleKeyword
-        OutputControl
-    LARGEPRINT : SimpleKeyword
-        OutputControl
-    SCFSOLVERTIME : SimpleKeyword
-        OutputControl
-    PRINTGAP : SimpleKeyword
-        OutputControl
-    PRINTMOS : SimpleKeyword
-        OutputControl
-    PRINTBASIS : SimpleKeyword
-        printbas
-    GRIDPRINT : SimpleKeyword
-        Print grid information
-    WRITEONLYINITIALPROPFILE : SimpleKeyword
-        Only write property file for first geometry
-    NOMOPRINT : SimpleKeyword
-        OutputControl
-    NOPROPFILE : SimpleKeyword
-        Write no property file
-    NOPRINTMOS : SimpleKeyword
-        OutputControl
-    """
+    """Enum to store all simple keywords of type OutputControl."""
 
     MINIPRINT = SimpleKeyword("miniprint")
+    """SimpleKeyword: OutputControl."""
     SMALLPRINT = SimpleKeyword("smallprint")
+    """SimpleKeyword: OutputControl."""
     NORMALPRINT = SimpleKeyword("normalprint")
+    """SimpleKeyword: OutputControl."""
     LARGEPRINT = SimpleKeyword("largeprint")
+    """SimpleKeyword: OutputControl."""
     SCFSOLVERTIME = SimpleKeyword("scfsolvertime")
+    """SimpleKeyword: OutputControl."""
     PRINTGAP = SimpleKeyword("printgap")
+    """SimpleKeyword: OutputControl."""
     PRINTMOS = SimpleKeyword("printmos")
+    """SimpleKeyword: OutputControl."""
     PRINTBASIS = SimpleKeyword("printbasis")
+    """SimpleKeyword: printbas."""
     GRIDPRINT = SimpleKeyword("gridprint")
+    """SimpleKeyword: Print grid information."""
     WRITEONLYINITIALPROPFILE = SimpleKeyword("writeonlyinitialpropfile")
+    """SimpleKeyword: Only write property file for first geometry."""
     NOMOPRINT = SimpleKeyword("nomoprint")
+    """SimpleKeyword: OutputControl."""
     NOPROPFILE = SimpleKeyword("nopropfile")
+    """SimpleKeyword: Write no property file."""
     NOPRINTMOS = SimpleKeyword("noprintmos")
+    """SimpleKeyword: OutputControl."""

--- a/src/opi/input/simple_keywords/property.py
+++ b/src/opi/input/simple_keywords/property.py
@@ -7,33 +7,21 @@ __all__ = ("Property",)
 
 
 class Property(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Property.
-
-    Attributes
-    ----------
-    NMR : SimpleKeyword
-        Calculate NMR parameters
-    G_TENSOR : SimpleKeyword
-        Calculate EPR parameters
-    UCO : SimpleKeyword
-        Property
-    NOUCO : SimpleKeyword
-        Property
-    UNO : SimpleKeyword
-        Property
-    NOUNO : SimpleKeyword
-        Property
-    NBO : SimpleKeyword
-        Property
-    NONBO : SimpleKeyword
-        Property
-    """
+    """Enum to store all simple keywords of type Property."""
 
     NMR = SimpleKeyword("nmr")
+    """SimpleKeyword: Calculate NMR parameters."""
     G_TENSOR = SimpleKeyword("g-tensor")
+    """SimpleKeyword: Calculate EPR parameters."""
     UCO = SimpleKeyword("uco")
+    """SimpleKeyword: Property."""
     NOUCO = SimpleKeyword("nouco")
+    """SimpleKeyword: Property."""
     UNO = SimpleKeyword("uno")
+    """SimpleKeyword: Property."""
     NOUNO = SimpleKeyword("nouno")
+    """SimpleKeyword: Property."""
     NBO = SimpleKeyword("nbo")
+    """SimpleKeyword: Property."""
     NONBO = SimpleKeyword("nonbo")
+    """SimpleKeyword: Property."""

--- a/src/opi/input/simple_keywords/property.py
+++ b/src/opi/input/simple_keywords/property.py
@@ -7,10 +7,30 @@ __all__ = ("Property",)
 
 
 class Property(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Property"""
+    """Enum to store all simple keywords of type Property.
 
-    NMR = SimpleKeyword("nmr")  # Calculate NMR parameters
-    G_TENSOR = SimpleKeyword("g-tensor")  # Calculate EPR parameters
+    Attributes
+    ----------
+    NMR : SimpleKeyword
+        Calculate NMR parameters
+    G_TENSOR : SimpleKeyword
+        Calculate EPR parameters
+    UCO : SimpleKeyword
+        Property
+    NOUCO : SimpleKeyword
+        Property
+    UNO : SimpleKeyword
+        Property
+    NOUNO : SimpleKeyword
+        Property
+    NBO : SimpleKeyword
+        Property
+    NONBO : SimpleKeyword
+        Property
+    """
+
+    NMR = SimpleKeyword("nmr")
+    G_TENSOR = SimpleKeyword("g-tensor")
     UCO = SimpleKeyword("uco")
     NOUCO = SimpleKeyword("nouco")
     UNO = SimpleKeyword("uno")

--- a/src/opi/input/simple_keywords/qmmm.py
+++ b/src/opi/input/simple_keywords/qmmm.py
@@ -7,50 +7,126 @@ __all__ = ("Qmmm",)
 
 
 class Qmmm(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Qmmm"""
+    """Enum to store all simple keywords of type Qmmm.
 
-    FMM_QMMM = SimpleKeyword("fmm-qmmm")  # Use FFM approximation in QMMM
-    IONIC_CRYSTAL_QMMM = SimpleKeyword(
-        "ionic-crystal-qmmm"
-    )  # Use QM/MM to simulate a condensed phase calculation
-    MOL_CRYSTAL_QMMM = SimpleKeyword(
-        "mol-crystal-qmmm"
-    )  # Use QM/MM to simulate a condensed phase calculation
-    MOLECULAR_CRYSTAL_QMMM = SimpleKeyword(
-        "molecular-crystal-qmmm"
-    )  # Use QM/MM to simulate a condensed phase calculation
-    QM_AM1 = SimpleKeyword("qm/am1")  # Predefined QM/MM level of theory
-    QM_AM1_MM = SimpleKeyword("qm/am1/mm")  # Predefined QM/MM level of theory
-    QM_AM1_SURFF = SimpleKeyword("qm/am1/surff")  # Predefined QM/MM level of theory
-    QM_GFN_FF = SimpleKeyword("qm/gfn-ff")  # Predefined QM/MM level of theory
-    QM_GFN_FF_MM = SimpleKeyword("qm/gfn-ff/mm")  # Predefined QM/MM level of theory
-    QM_HF_3C = SimpleKeyword("qm/hf-3c")  # Predefined QM/MM level of theory
-    QM_HF_3C_MM = SimpleKeyword("qm/hf-3c/mm")  # Predefined QM/MM level of theory
-    QM_HF_3C_SURFF = SimpleKeyword("qm/hf-3c/surff")  # Predefined QM/MM level of theory
-    QM_PBEH_3C = SimpleKeyword("qm/pbeh-3c")  # Predefined QM/MM level of theory
-    QM_PBEH_3C_MM = SimpleKeyword("qm/pbeh-3c/mm")  # Predefined QM/MM level of theory
-    QM_PBEH_3C_SURFF = SimpleKeyword("qm/pbeh-3c/surff")  # Predefined QM/MM level of theory
-    QM_PM3 = SimpleKeyword("qm/pm3")  # Predefined QM/MM level of theory
-    QM_PM3_MM = SimpleKeyword("qm/pm3/mm")  # Predefined QM/MM level of theory
-    QM_PM3_SURFF = SimpleKeyword("qm/pm3/surff")  # Predefined QM/MM level of theory
-    QM_QM2 = SimpleKeyword("qm/qm2")  # Predefined QM/MM level of theory
-    QM_QM2_MM = SimpleKeyword("qm/qm2/mm")  # Predefined QM/MM level of theory
-    QM_QM2_SURFF = SimpleKeyword("qm/qm2/surff")  # Predefined QM/MM level of theory
-    QM_R2SCAN_3C = SimpleKeyword("qm/r2scan-3c")  # Predefined QM/MM level of theory
-    QM_R2SCAN_3C_MM = SimpleKeyword("qm/r2scan-3c/mm")  # Predefined QM/MM level of theory
-    QM_R2SCAN_3C_SURFF = SimpleKeyword("qm/r2scan-3c/surff")  # Predefined QM/MM level of theory
-    QM_R2SCAN3C = SimpleKeyword("qm/r2scan3c")  # Predefined QM/MM level of theory
-    QM_R2SCAN3C_MM = SimpleKeyword("qm/r2scan3c/mm")  # Predefined QM/MM level of theory
-    QM_R2SCAN3C_SURFF = SimpleKeyword("qm/r2scan3c/surff")  # Predefined QM/MM level of theory
-    QM_SURFF = SimpleKeyword("qm/surff")  # Predefined QM/MM level of theory
-    QM_SURFF_MM = SimpleKeyword("qm/surff/mm")  # Predefined QM/MM level of theory
-    QM_XTB0 = SimpleKeyword("qm/xtb0")  # Predefined QM/MM level of theory
-    QM_XTB0_MM = SimpleKeyword("qm/xtb0/mm")  # Predefined QM/MM level of theory
-    QM_XTB1 = SimpleKeyword("qm/xtb1")  # Predefined QM/MM level of theory
-    QM_XTB1_MM = SimpleKeyword("qm/xtb1/mm")  # Predefined QM/MM level of theory
-    QM_XTB2 = SimpleKeyword("qm/xtb2")  # Predefined QM/MM level of theory
-    QM_XTB2_GFN_FF = SimpleKeyword("qm/xtb2/gfn-ff")  # Predefined QM/MM level of theory
-    QM_XTB2_MM = SimpleKeyword("qm/xtb2/mm")  # Predefined QM/MM level of theory
-    QM_XTB2_SURFF = SimpleKeyword("qm/xtb2/surff")  # Predefined QM/MM level of theory
-    QMMM = SimpleKeyword("qmmm")  # Use QMMM
-    QMMMSETUP = SimpleKeyword("qmmmsetup")  # Use QMMM (only does the setup)
+    Attributes
+    ----------
+    FMM_QMMM : SimpleKeyword
+        Use FFM approximation in QMMM
+    IONIC_CRYSTAL_QMMM : SimpleKeyword
+        Use QM/MM to simulate a condensed phase calculation
+    MOL_CRYSTAL_QMMM : SimpleKeyword
+        Use QM/MM to simulate a condensed phase calculation
+    MOLECULAR_CRYSTAL_QMMM : SimpleKeyword
+        Use QM/MM to simulate a condensed phase calculation
+    QM_AM1 : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_AM1_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_AM1_SURFF : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_GFN_FF : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_GFN_FF_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_HF_3C : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_HF_3C_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_HF_3C_SURFF : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_PBEH_3C : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_PBEH_3C_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_PBEH_3C_SURFF : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_PM3 : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_PM3_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_PM3_SURFF : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_QM2 : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_QM2_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_QM2_SURFF : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_R2SCAN_3C : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_R2SCAN_3C_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_R2SCAN_3C_SURFF : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_R2SCAN3C : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_R2SCAN3C_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_R2SCAN3C_SURFF : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_SURFF : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_SURFF_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_XTB0 : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_XTB0_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_XTB1 : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_XTB1_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_XTB2 : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_XTB2_GFN_FF : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_XTB2_MM : SimpleKeyword
+        Predefined QM/MM level of theory
+    QM_XTB2_SURFF : SimpleKeyword
+        Predefined QM/MM level of theory
+    QMMM : SimpleKeyword
+        Use QMMM
+    QMMMSETUP : SimpleKeyword
+        Use QMMM (only does the setup)
+    """
+
+    FMM_QMMM = SimpleKeyword("fmm-qmmm")
+    IONIC_CRYSTAL_QMMM = SimpleKeyword("ionic-crystal-qmmm")
+    MOL_CRYSTAL_QMMM = SimpleKeyword("mol-crystal-qmmm")
+    MOLECULAR_CRYSTAL_QMMM = SimpleKeyword("molecular-crystal-qmmm")
+    QM_AM1 = SimpleKeyword("qm/am1")
+    QM_AM1_MM = SimpleKeyword("qm/am1/mm")
+    QM_AM1_SURFF = SimpleKeyword("qm/am1/surff")
+    QM_GFN_FF = SimpleKeyword("qm/gfn-ff")
+    QM_GFN_FF_MM = SimpleKeyword("qm/gfn-ff/mm")
+    QM_HF_3C = SimpleKeyword("qm/hf-3c")
+    QM_HF_3C_MM = SimpleKeyword("qm/hf-3c/mm")
+    QM_HF_3C_SURFF = SimpleKeyword("qm/hf-3c/surff")
+    QM_PBEH_3C = SimpleKeyword("qm/pbeh-3c")
+    QM_PBEH_3C_MM = SimpleKeyword("qm/pbeh-3c/mm")
+    QM_PBEH_3C_SURFF = SimpleKeyword("qm/pbeh-3c/surff")
+    QM_PM3 = SimpleKeyword("qm/pm3")
+    QM_PM3_MM = SimpleKeyword("qm/pm3/mm")
+    QM_PM3_SURFF = SimpleKeyword("qm/pm3/surff")
+    QM_QM2 = SimpleKeyword("qm/qm2")
+    QM_QM2_MM = SimpleKeyword("qm/qm2/mm")
+    QM_QM2_SURFF = SimpleKeyword("qm/qm2/surff")
+    QM_R2SCAN_3C = SimpleKeyword("qm/r2scan-3c")
+    QM_R2SCAN_3C_MM = SimpleKeyword("qm/r2scan-3c/mm")
+    QM_R2SCAN_3C_SURFF = SimpleKeyword("qm/r2scan-3c/surff")
+    QM_R2SCAN3C = SimpleKeyword("qm/r2scan3c")
+    QM_R2SCAN3C_MM = SimpleKeyword("qm/r2scan3c/mm")
+    QM_R2SCAN3C_SURFF = SimpleKeyword("qm/r2scan3c/surff")
+    QM_SURFF = SimpleKeyword("qm/surff")
+    QM_SURFF_MM = SimpleKeyword("qm/surff/mm")
+    QM_XTB0 = SimpleKeyword("qm/xtb0")
+    QM_XTB0_MM = SimpleKeyword("qm/xtb0/mm")
+    QM_XTB1 = SimpleKeyword("qm/xtb1")
+    QM_XTB1_MM = SimpleKeyword("qm/xtb1/mm")
+    QM_XTB2 = SimpleKeyword("qm/xtb2")
+    QM_XTB2_GFN_FF = SimpleKeyword("qm/xtb2/gfn-ff")
+    QM_XTB2_MM = SimpleKeyword("qm/xtb2/mm")
+    QM_XTB2_SURFF = SimpleKeyword("qm/xtb2/surff")
+    QMMM = SimpleKeyword("qmmm")
+    QMMMSETUP = SimpleKeyword("qmmmsetup")

--- a/src/opi/input/simple_keywords/qmmm.py
+++ b/src/opi/input/simple_keywords/qmmm.py
@@ -7,126 +7,83 @@ __all__ = ("Qmmm",)
 
 
 class Qmmm(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Qmmm.
-
-    Attributes
-    ----------
-    FMM_QMMM : SimpleKeyword
-        Use FFM approximation in QMMM
-    IONIC_CRYSTAL_QMMM : SimpleKeyword
-        Use QM/MM to simulate a condensed phase calculation
-    MOL_CRYSTAL_QMMM : SimpleKeyword
-        Use QM/MM to simulate a condensed phase calculation
-    MOLECULAR_CRYSTAL_QMMM : SimpleKeyword
-        Use QM/MM to simulate a condensed phase calculation
-    QM_AM1 : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_AM1_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_AM1_SURFF : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_GFN_FF : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_GFN_FF_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_HF_3C : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_HF_3C_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_HF_3C_SURFF : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_PBEH_3C : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_PBEH_3C_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_PBEH_3C_SURFF : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_PM3 : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_PM3_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_PM3_SURFF : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_QM2 : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_QM2_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_QM2_SURFF : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_R2SCAN_3C : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_R2SCAN_3C_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_R2SCAN_3C_SURFF : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_R2SCAN3C : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_R2SCAN3C_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_R2SCAN3C_SURFF : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_SURFF : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_SURFF_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_XTB0 : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_XTB0_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_XTB1 : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_XTB1_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_XTB2 : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_XTB2_GFN_FF : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_XTB2_MM : SimpleKeyword
-        Predefined QM/MM level of theory
-    QM_XTB2_SURFF : SimpleKeyword
-        Predefined QM/MM level of theory
-    QMMM : SimpleKeyword
-        Use QMMM
-    QMMMSETUP : SimpleKeyword
-        Use QMMM (only does the setup)
-    """
+    """Enum to store all simple keywords of type Qmmm."""
 
     FMM_QMMM = SimpleKeyword("fmm-qmmm")
+    """SimpleKeyword: Use FFM approximation in QMMM."""
     IONIC_CRYSTAL_QMMM = SimpleKeyword("ionic-crystal-qmmm")
+    """SimpleKeyword: Use QM/MM to simulate a condensed phase calculation."""
     MOL_CRYSTAL_QMMM = SimpleKeyword("mol-crystal-qmmm")
+    """SimpleKeyword: Use QM/MM to simulate a condensed phase calculation."""
     MOLECULAR_CRYSTAL_QMMM = SimpleKeyword("molecular-crystal-qmmm")
+    """SimpleKeyword: Use QM/MM to simulate a condensed phase calculation."""
     QM_AM1 = SimpleKeyword("qm/am1")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_AM1_MM = SimpleKeyword("qm/am1/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_AM1_SURFF = SimpleKeyword("qm/am1/surff")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_GFN_FF = SimpleKeyword("qm/gfn-ff")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_GFN_FF_MM = SimpleKeyword("qm/gfn-ff/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_HF_3C = SimpleKeyword("qm/hf-3c")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_HF_3C_MM = SimpleKeyword("qm/hf-3c/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_HF_3C_SURFF = SimpleKeyword("qm/hf-3c/surff")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_PBEH_3C = SimpleKeyword("qm/pbeh-3c")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_PBEH_3C_MM = SimpleKeyword("qm/pbeh-3c/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_PBEH_3C_SURFF = SimpleKeyword("qm/pbeh-3c/surff")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_PM3 = SimpleKeyword("qm/pm3")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_PM3_MM = SimpleKeyword("qm/pm3/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_PM3_SURFF = SimpleKeyword("qm/pm3/surff")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_QM2 = SimpleKeyword("qm/qm2")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_QM2_MM = SimpleKeyword("qm/qm2/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_QM2_SURFF = SimpleKeyword("qm/qm2/surff")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_R2SCAN_3C = SimpleKeyword("qm/r2scan-3c")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_R2SCAN_3C_MM = SimpleKeyword("qm/r2scan-3c/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_R2SCAN_3C_SURFF = SimpleKeyword("qm/r2scan-3c/surff")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_R2SCAN3C = SimpleKeyword("qm/r2scan3c")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_R2SCAN3C_MM = SimpleKeyword("qm/r2scan3c/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_R2SCAN3C_SURFF = SimpleKeyword("qm/r2scan3c/surff")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_SURFF = SimpleKeyword("qm/surff")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_SURFF_MM = SimpleKeyword("qm/surff/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_XTB0 = SimpleKeyword("qm/xtb0")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_XTB0_MM = SimpleKeyword("qm/xtb0/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_XTB1 = SimpleKeyword("qm/xtb1")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_XTB1_MM = SimpleKeyword("qm/xtb1/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_XTB2 = SimpleKeyword("qm/xtb2")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_XTB2_GFN_FF = SimpleKeyword("qm/xtb2/gfn-ff")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_XTB2_MM = SimpleKeyword("qm/xtb2/mm")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QM_XTB2_SURFF = SimpleKeyword("qm/xtb2/surff")
+    """SimpleKeyword: Predefined QM/MM level of theory."""
     QMMM = SimpleKeyword("qmmm")
+    """SimpleKeyword: Use QMMM."""
     QMMMSETUP = SimpleKeyword("qmmmsetup")
+    """SimpleKeyword: Use QMMM (only does the setup)."""

--- a/src/opi/input/simple_keywords/relativistic_correction.py
+++ b/src/opi/input/simple_keywords/relativistic_correction.py
@@ -7,7 +7,71 @@ __all__ = ("RelativisticCorrection",)
 
 
 class RelativisticCorrection(SimpleKeywordBox):
-    """Enum to store all simple keywords of type RelativisticCorrection"""
+    """Enum to store all simple keywords of type RelativisticCorrection.
+
+    Attributes
+    ----------
+    AMFI : SimpleKeyword
+        RelativisticCorrection
+    DBOC : SimpleKeyword
+        RelativisticCorrection
+    DKH : SimpleKeyword
+        RelativisticCorrection
+    DKH1 : SimpleKeyword
+        RelativisticCorrection
+    DKH2 : SimpleKeyword
+        RelativisticCorrection
+    DLU_X2C : SimpleKeyword
+        RelativisticCorrection
+    IORA : SimpleKeyword
+        RelativisticCorrection
+    IORA_RI : SimpleKeyword
+        RelativisticCorrection
+    IORAMM_RI : SimpleKeyword
+        RelativisticCorrection
+    NESC : SimpleKeyword
+        RelativisticCorrection
+    NODBOC : SimpleKeyword
+        RelativisticCorrection
+    NOSOCENERGY : SimpleKeyword
+        RelativisticCorrection
+    REL1C : SimpleKeyword
+        RelativisticCorrection
+    RELDLU : SimpleKeyword
+        RelativisticCorrection
+    RELFULL : SimpleKeyword
+        RelativisticCorrection
+    RI_SOMF : SimpleKeyword
+        RelativisticCorrection
+    RI_SOMF_1X : SimpleKeyword
+        RelativisticCorrection
+    RI_SOMF_4X : SimpleKeyword
+        RelativisticCorrection
+    RI_SOMF_4XS : SimpleKeyword
+        RelativisticCorrection
+    SOCENERGY : SimpleKeyword
+        RelativisticCorrection
+    SOMF : SimpleKeyword
+        RelativisticCorrection
+    SOMF_1X : SimpleKeyword
+        RelativisticCorrection
+    SOMF_4X : SimpleKeyword
+        RelativisticCorrection
+    SOMF_4XS : SimpleKeyword
+        RelativisticCorrection
+    VEFF_SOC : SimpleKeyword
+        RelativisticCorrection
+    VEFF_2X_SOC : SimpleKeyword
+        RelativisticCorrection
+    X2C : SimpleKeyword
+        RelativisticCorrection
+    ZEFF_SOC : SimpleKeyword
+        RelativisticCorrection
+    ZORA : SimpleKeyword
+        RelativisticCorrection
+    ZORA_RI : SimpleKeyword
+        RelativisticCorrection
+    """
 
     AMFI = SimpleKeyword("amfi")
     DBOC = SimpleKeyword("dboc")

--- a/src/opi/input/simple_keywords/relativistic_correction.py
+++ b/src/opi/input/simple_keywords/relativistic_correction.py
@@ -7,99 +7,65 @@ __all__ = ("RelativisticCorrection",)
 
 
 class RelativisticCorrection(SimpleKeywordBox):
-    """Enum to store all simple keywords of type RelativisticCorrection.
-
-    Attributes
-    ----------
-    AMFI : SimpleKeyword
-        RelativisticCorrection
-    DBOC : SimpleKeyword
-        RelativisticCorrection
-    DKH : SimpleKeyword
-        RelativisticCorrection
-    DKH1 : SimpleKeyword
-        RelativisticCorrection
-    DKH2 : SimpleKeyword
-        RelativisticCorrection
-    DLU_X2C : SimpleKeyword
-        RelativisticCorrection
-    IORA : SimpleKeyword
-        RelativisticCorrection
-    IORA_RI : SimpleKeyword
-        RelativisticCorrection
-    IORAMM_RI : SimpleKeyword
-        RelativisticCorrection
-    NESC : SimpleKeyword
-        RelativisticCorrection
-    NODBOC : SimpleKeyword
-        RelativisticCorrection
-    NOSOCENERGY : SimpleKeyword
-        RelativisticCorrection
-    REL1C : SimpleKeyword
-        RelativisticCorrection
-    RELDLU : SimpleKeyword
-        RelativisticCorrection
-    RELFULL : SimpleKeyword
-        RelativisticCorrection
-    RI_SOMF : SimpleKeyword
-        RelativisticCorrection
-    RI_SOMF_1X : SimpleKeyword
-        RelativisticCorrection
-    RI_SOMF_4X : SimpleKeyword
-        RelativisticCorrection
-    RI_SOMF_4XS : SimpleKeyword
-        RelativisticCorrection
-    SOCENERGY : SimpleKeyword
-        RelativisticCorrection
-    SOMF : SimpleKeyword
-        RelativisticCorrection
-    SOMF_1X : SimpleKeyword
-        RelativisticCorrection
-    SOMF_4X : SimpleKeyword
-        RelativisticCorrection
-    SOMF_4XS : SimpleKeyword
-        RelativisticCorrection
-    VEFF_SOC : SimpleKeyword
-        RelativisticCorrection
-    VEFF_2X_SOC : SimpleKeyword
-        RelativisticCorrection
-    X2C : SimpleKeyword
-        RelativisticCorrection
-    ZEFF_SOC : SimpleKeyword
-        RelativisticCorrection
-    ZORA : SimpleKeyword
-        RelativisticCorrection
-    ZORA_RI : SimpleKeyword
-        RelativisticCorrection
-    """
+    """Enum to store all simple keywords of type RelativisticCorrection."""
 
     AMFI = SimpleKeyword("amfi")
+    """SimpleKeyword: RelativisticCorrection."""
     DBOC = SimpleKeyword("dboc")
+    """SimpleKeyword: RelativisticCorrection."""
     DKH = SimpleKeyword("dkh")
+    """SimpleKeyword: RelativisticCorrection."""
     DKH1 = SimpleKeyword("dkh1")
+    """SimpleKeyword: RelativisticCorrection."""
     DKH2 = SimpleKeyword("dkh2")
+    """SimpleKeyword: RelativisticCorrection."""
     DLU_X2C = SimpleKeyword("dlu-x2c")
+    """SimpleKeyword: RelativisticCorrection."""
     IORA = SimpleKeyword("iora")
+    """SimpleKeyword: RelativisticCorrection."""
     IORA_RI = SimpleKeyword("iora/ri")
+    """SimpleKeyword: RelativisticCorrection."""
     IORAMM_RI = SimpleKeyword("ioramm/ri")
+    """SimpleKeyword: RelativisticCorrection."""
     NESC = SimpleKeyword("nesc")
+    """SimpleKeyword: RelativisticCorrection."""
     NODBOC = SimpleKeyword("nodboc")
+    """SimpleKeyword: RelativisticCorrection."""
     NOSOCENERGY = SimpleKeyword("nosocenergy")
+    """SimpleKeyword: RelativisticCorrection."""
     REL1C = SimpleKeyword("rel1c")
+    """SimpleKeyword: RelativisticCorrection."""
     RELDLU = SimpleKeyword("reldlu")
+    """SimpleKeyword: RelativisticCorrection."""
     RELFULL = SimpleKeyword("relfull")
+    """SimpleKeyword: RelativisticCorrection."""
     RI_SOMF = SimpleKeyword("ri-somf")
+    """SimpleKeyword: RelativisticCorrection."""
     RI_SOMF_1X = SimpleKeyword("ri-somf(1x)")
+    """SimpleKeyword: RelativisticCorrection."""
     RI_SOMF_4X = SimpleKeyword("ri-somf(4x)")
+    """SimpleKeyword: RelativisticCorrection."""
     RI_SOMF_4XS = SimpleKeyword("ri-somf(4xs)")
+    """SimpleKeyword: RelativisticCorrection."""
     SOCENERGY = SimpleKeyword("socenergy")
+    """SimpleKeyword: RelativisticCorrection."""
     SOMF = SimpleKeyword("somf")
+    """SimpleKeyword: RelativisticCorrection."""
     SOMF_1X = SimpleKeyword("somf(1x)")
+    """SimpleKeyword: RelativisticCorrection."""
     SOMF_4X = SimpleKeyword("somf(4x)")
+    """SimpleKeyword: RelativisticCorrection."""
     SOMF_4XS = SimpleKeyword("somf(4xs)")
+    """SimpleKeyword: RelativisticCorrection."""
     VEFF_SOC = SimpleKeyword("veff-soc")
+    """SimpleKeyword: RelativisticCorrection."""
     VEFF_2X_SOC = SimpleKeyword("veff(-2x)-soc")
+    """SimpleKeyword: RelativisticCorrection."""
     X2C = SimpleKeyword("x2c")
+    """SimpleKeyword: RelativisticCorrection."""
     ZEFF_SOC = SimpleKeyword("zeff-soc")
+    """SimpleKeyword: RelativisticCorrection."""
     ZORA = SimpleKeyword("zora")
+    """SimpleKeyword: RelativisticCorrection."""
     ZORA_RI = SimpleKeyword("zora/ri")
+    """SimpleKeyword: RelativisticCorrection."""

--- a/src/opi/input/simple_keywords/scf.py
+++ b/src/opi/input/simple_keywords/scf.py
@@ -7,85 +7,231 @@ __all__ = ("Scf",)
 
 
 class Scf(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Scf"""
+    """Enum to store all simple keywords of type Scf.
 
-    G3CONV = SimpleKeyword("3conv")  # SCF solver combination
-    AODIISTRAH = SimpleKeyword("aodiistrah")  # SCF solver combination
-    DIISTRAH = SimpleKeyword("diistrah")  # SCF solver combination
-    KDIISTRAH = SimpleKeyword("kdiistrah")  # SCF solver combination
-    DIIS = SimpleKeyword("diis")  # SCF solver
-    NODIIS = SimpleKeyword("nodiis")  # SCF solver
-    AODIIS = SimpleKeyword("aodiis")  # SCF solver
-    NOAODIIS = SimpleKeyword("noaodiis")  # SCF solver
-    KDIIS = SimpleKeyword("kdiis")  # SCF solver
-    NOKDIIS = SimpleKeyword("nokdiis")  # SCF solver
-    SOSCF = SimpleKeyword("soscf")  # SCF solver
-    NOSOSCF = SimpleKeyword("nososcf")  # SCF solver
-    TRAH = SimpleKeyword("trah")  # SCF solver
-    NOTRAH = SimpleKeyword("notrah")  # SCF solver
-    AUTOSTART = SimpleKeyword(
-        "autostart"
-    )  # SCF initial guess start SCF from a gbw file with the same basename (default)
-    NOAUTOSTART = SimpleKeyword(
-        "noautostart"
-    )  # SCF initial guess do not start SCF from a gbw file with the same basename
-    MOREAD = SimpleKeyword("moread")  # SCF initial guess read orbitals from gbw file
-    EHTANO = SimpleKeyword("ehtano")  # SCF initial guess
-    HCORE = SimpleKeyword("hcore")  # SCF initial guess
-    HUECKEL = SimpleKeyword("hueckel")  # SCF initial guess
-    PATOM = SimpleKeyword("patom")  # SCF initial guess
-    PMODEL = SimpleKeyword("pmodel")  # SCF initial guess
-    PMODELX = SimpleKeyword("pmodelx")  # SCF initial guess
-    PMODELXAV = SimpleKeyword("pmodelxav")  # SCF initial guess
-    PMODELXPM = SimpleKeyword("pmodelxpm")  # SCF initial guess
-    SYMBREAKGUESS = SimpleKeyword("symbreakguess")  # SCF initial guess
-    UNITMATRIXGUESS = SimpleKeyword("unitmatrixguess")  # SCF initial guess
-    USEGRAMSCHMIDT = SimpleKeyword("usegramschmidt")  # SCF initial guess
-    CALCGUESSENERGY = SimpleKeyword("calcguessenergy")  # Calculate the guess energy
-    CONV = SimpleKeyword("conv")  # Conventional SCF
-    SEMIDIRECT = SimpleKeyword("semidirect")  # Semidirect SCF
-    DIRECT = SimpleKeyword("direct")  # Direct SCF
-    SCFSTAB = SimpleKeyword("scfstab")  # SCF stability analysis
-    NOSCFSTAB = SimpleKeyword("noscfstab")  # No SCF stability analysis
-    DELTASCF = SimpleKeyword("deltascf")  # DeltaSCF for access to excited states
-    FRSOSCF = SimpleKeyword("frsoscf")  # freeze and release DeltaSCF settings
-    GMF = SimpleKeyword("gmf")  # DeltaSCF settings
-    SMEAR = SimpleKeyword("smear")  # do finite temperature DFT (smearing)
-    NOSMEAR = SimpleKeyword("nosmear")  # do not use finite temperature DFT (smearing)
-    FRACOCC = SimpleKeyword("fracocc")  # enable fractional occupations
-    SCFCONVFORCED = SimpleKeyword(
-        "scfconvforced"
-    )  # Force SCF convergence for subsequent operations
-    SLOPPYSCF = SimpleKeyword("sloppyscf")  # SCF convergence threshold settings
-    LOOSESCF = SimpleKeyword("loosescf")  # SCF convergence threshold settings
-    NORMALSCF = SimpleKeyword("normalscf")  # SCF convergence threshold settings
-    STRONGSCF = SimpleKeyword("strongscf")  # SCF convergence threshold settings
-    TIGHTSCF = SimpleKeyword("tightscf")  # SCF convergence threshold settings
-    VERYTIGHTSCF = SimpleKeyword("verytightscf")  # SCF convergence threshold settings
-    EXTREMESCF = SimpleKeyword("extremescf")  # SCF convergence threshold settings
-    SLOPPYSCFCHECK = SimpleKeyword("sloppyscfcheck")  # SCF convergence threshold settings
-    NOSLOPPYSCFCHECK = SimpleKeyword("nosloppyscfcheck")  # SCF convergence threshold settings
-    SCFCHECKGRAD = SimpleKeyword("scfcheckgrad")  # SCF convergence threshold settings
-    SCFCONV6 = SimpleKeyword("scfconv6")  # SCF convergence threshold settings
-    SCFCONV7 = SimpleKeyword("scfconv7")  # SCF convergence threshold settings
-    SCFCONV8 = SimpleKeyword("scfconv8")  # SCF convergence threshold settings
-    SCFCONV9 = SimpleKeyword("scfconv9")  # SCF convergence threshold settings
-    SCFCONV10 = SimpleKeyword("scfconv10")  # SCF convergence threshold settings
-    SCFCONV11 = SimpleKeyword("scfconv11")  # SCF convergence threshold settings
-    SCFCONV12 = SimpleKeyword("scfconv12")  # SCF convergence threshold settings
-    EASYCONV = SimpleKeyword("easyconv")  # SCF convergence strategy
-    NORMALCONV = SimpleKeyword("normalconv")  # SCF convergence strategy
-    SLOWCONV = SimpleKeyword("slowconv")  # SCF convergence strategy
-    VERYSLOWCONV = SimpleKeyword("veryslowconv")  # SCF convergence strategy
-    DAMP = SimpleKeyword("damp")  # SCF settings
-    NODAMP = SimpleKeyword("nodamp")  # SCF settings
-    LSHIFT = SimpleKeyword("lshift")  # SCF settings
-    NOLSHIFT = SimpleKeyword("nolshift")  # SCF settings
-    USEINCREMENTAL = SimpleKeyword("useincremental")  # SCF settings
-    NOINCREMENTAL = SimpleKeyword("noincremental")  # SCF settings
-    NOITER = SimpleKeyword("noiter")  # SCF settings no iterations
-    SCFLBFGS = SimpleKeyword("scflbfgs")  # SOSCF settings
-    SCFLBOFILL = SimpleKeyword("scflbofill")  # SOSCF settings
-    SCFLPOWELL = SimpleKeyword("scflpowell")  # SOSCF settings
-    SCFLSR1 = SimpleKeyword("scflsr1")  # SOSCF settings
-    NOTRAHRANDOMIZE = SimpleKeyword("notrahrandomize")  # TRAH settings
+    Attributes
+    ----------
+    G3CONV : SimpleKeyword
+        SCF solver combination
+    AODIISTRAH : SimpleKeyword
+        SCF solver combination
+    DIISTRAH : SimpleKeyword
+        SCF solver combination
+    KDIISTRAH : SimpleKeyword
+        SCF solver combination
+    DIIS : SimpleKeyword
+        SCF solver
+    NODIIS : SimpleKeyword
+        SCF solver
+    AODIIS : SimpleKeyword
+        SCF solver
+    NOAODIIS : SimpleKeyword
+        SCF solver
+    KDIIS : SimpleKeyword
+        SCF solver
+    NOKDIIS : SimpleKeyword
+        SCF solver
+    SOSCF : SimpleKeyword
+        SCF solver
+    NOSOSCF : SimpleKeyword
+        SCF solver
+    TRAH : SimpleKeyword
+        SCF solver
+    NOTRAH : SimpleKeyword
+        SCF solver
+    AUTOSTART : SimpleKeyword
+        SCF initial guess start SCF from a gbw file with the same basename (default)
+    NOAUTOSTART : SimpleKeyword
+        SCF initial guess do not start SCF from a gbw file with the same basename
+    MOREAD : SimpleKeyword
+        SCF initial guess read orbitals from gbw file
+    EHTANO : SimpleKeyword
+        SCF initial guess
+    HCORE : SimpleKeyword
+        SCF initial guess
+    HUECKEL : SimpleKeyword
+        SCF initial guess
+    PATOM : SimpleKeyword
+        SCF initial guess
+    PMODEL : SimpleKeyword
+        SCF initial guess
+    PMODELX : SimpleKeyword
+        SCF initial guess
+    PMODELXAV : SimpleKeyword
+        SCF initial guess
+    PMODELXPM : SimpleKeyword
+        SCF initial guess
+    SYMBREAKGUESS : SimpleKeyword
+        SCF initial guess
+    UNITMATRIXGUESS : SimpleKeyword
+        SCF initial guess
+    USEGRAMSCHMIDT : SimpleKeyword
+        SCF initial guess
+    CALCGUESSENERGY : SimpleKeyword
+        Calculate the guess energy
+    CONV : SimpleKeyword
+        Conventional SCF
+    SEMIDIRECT : SimpleKeyword
+        Semidirect SCF
+    DIRECT : SimpleKeyword
+        Direct SCF
+    SCFSTAB : SimpleKeyword
+        SCF stability analysis
+    NOSCFSTAB : SimpleKeyword
+        No SCF stability analysis
+    DELTASCF : SimpleKeyword
+        DeltaSCF for access to excited states
+    FRSOSCF : SimpleKeyword
+        freeze and release DeltaSCF settings
+    GMF : SimpleKeyword
+        DeltaSCF settings
+    SMEAR : SimpleKeyword
+        do finite temperature DFT (smearing)
+    NOSMEAR : SimpleKeyword
+        do not use finite temperature DFT (smearing)
+    FRACOCC : SimpleKeyword
+        enable fractional occupations
+    SCFCONVFORCED : SimpleKeyword
+        Force SCF convergence for subsequent operations
+    SLOPPYSCF : SimpleKeyword
+        SCF convergence threshold settings
+    LOOSESCF : SimpleKeyword
+        SCF convergence threshold settings
+    NORMALSCF : SimpleKeyword
+        SCF convergence threshold settings
+    STRONGSCF : SimpleKeyword
+        SCF convergence threshold settings
+    TIGHTSCF : SimpleKeyword
+        SCF convergence threshold settings
+    VERYTIGHTSCF : SimpleKeyword
+        SCF convergence threshold settings
+    EXTREMESCF : SimpleKeyword
+        SCF convergence threshold settings
+    SLOPPYSCFCHECK : SimpleKeyword
+        SCF convergence threshold settings
+    NOSLOPPYSCFCHECK : SimpleKeyword
+        SCF convergence threshold settings
+    SCFCHECKGRAD : SimpleKeyword
+        SCF convergence threshold settings
+    SCFCONV6 : SimpleKeyword
+        SCF convergence threshold settings
+    SCFCONV7 : SimpleKeyword
+        SCF convergence threshold settings
+    SCFCONV8 : SimpleKeyword
+        SCF convergence threshold settings
+    SCFCONV9 : SimpleKeyword
+        SCF convergence threshold settings
+    SCFCONV10 : SimpleKeyword
+        SCF convergence threshold settings
+    SCFCONV11 : SimpleKeyword
+        SCF convergence threshold settings
+    SCFCONV12 : SimpleKeyword
+        SCF convergence threshold settings
+    EASYCONV : SimpleKeyword
+        SCF convergence strategy
+    NORMALCONV : SimpleKeyword
+        SCF convergence strategy
+    SLOWCONV : SimpleKeyword
+        SCF convergence strategy
+    VERYSLOWCONV : SimpleKeyword
+        SCF convergence strategy
+    DAMP : SimpleKeyword
+        SCF settings
+    NODAMP : SimpleKeyword
+        SCF settings
+    LSHIFT : SimpleKeyword
+        SCF settings
+    NOLSHIFT : SimpleKeyword
+        SCF settings
+    USEINCREMENTAL : SimpleKeyword
+        SCF settings
+    NOINCREMENTAL : SimpleKeyword
+        SCF settings
+    NOITER : SimpleKeyword
+        SCF settings no iterations
+    SCFLBFGS : SimpleKeyword
+        SOSCF settings
+    SCFLBOFILL : SimpleKeyword
+        SOSCF settings
+    SCFLPOWELL : SimpleKeyword
+        SOSCF settings
+    SCFLSR1 : SimpleKeyword
+        SOSCF settings
+    NOTRAHRANDOMIZE : SimpleKeyword
+        TRAH settings
+    """
+
+    G3CONV = SimpleKeyword("3conv")
+    AODIISTRAH = SimpleKeyword("aodiistrah")
+    DIISTRAH = SimpleKeyword("diistrah")
+    KDIISTRAH = SimpleKeyword("kdiistrah")
+    DIIS = SimpleKeyword("diis")
+    NODIIS = SimpleKeyword("nodiis")
+    AODIIS = SimpleKeyword("aodiis")
+    NOAODIIS = SimpleKeyword("noaodiis")
+    KDIIS = SimpleKeyword("kdiis")
+    NOKDIIS = SimpleKeyword("nokdiis")
+    SOSCF = SimpleKeyword("soscf")
+    NOSOSCF = SimpleKeyword("nososcf")
+    TRAH = SimpleKeyword("trah")
+    NOTRAH = SimpleKeyword("notrah")
+    AUTOSTART = SimpleKeyword("autostart")
+    NOAUTOSTART = SimpleKeyword("noautostart")
+    MOREAD = SimpleKeyword("moread")
+    EHTANO = SimpleKeyword("ehtano")
+    HCORE = SimpleKeyword("hcore")
+    HUECKEL = SimpleKeyword("hueckel")
+    PATOM = SimpleKeyword("patom")
+    PMODEL = SimpleKeyword("pmodel")
+    PMODELX = SimpleKeyword("pmodelx")
+    PMODELXAV = SimpleKeyword("pmodelxav")
+    PMODELXPM = SimpleKeyword("pmodelxpm")
+    SYMBREAKGUESS = SimpleKeyword("symbreakguess")
+    UNITMATRIXGUESS = SimpleKeyword("unitmatrixguess")
+    USEGRAMSCHMIDT = SimpleKeyword("usegramschmidt")
+    CALCGUESSENERGY = SimpleKeyword("calcguessenergy")
+    CONV = SimpleKeyword("conv")
+    SEMIDIRECT = SimpleKeyword("semidirect")
+    DIRECT = SimpleKeyword("direct")
+    SCFSTAB = SimpleKeyword("scfstab")
+    NOSCFSTAB = SimpleKeyword("noscfstab")
+    DELTASCF = SimpleKeyword("deltascf")
+    FRSOSCF = SimpleKeyword("frsoscf")
+    GMF = SimpleKeyword("gmf")
+    SMEAR = SimpleKeyword("smear")
+    NOSMEAR = SimpleKeyword("nosmear")
+    FRACOCC = SimpleKeyword("fracocc")
+    SCFCONVFORCED = SimpleKeyword("scfconvforced")
+    SLOPPYSCF = SimpleKeyword("sloppyscf")
+    LOOSESCF = SimpleKeyword("loosescf")
+    NORMALSCF = SimpleKeyword("normalscf")
+    STRONGSCF = SimpleKeyword("strongscf")
+    TIGHTSCF = SimpleKeyword("tightscf")
+    VERYTIGHTSCF = SimpleKeyword("verytightscf")
+    EXTREMESCF = SimpleKeyword("extremescf")
+    SLOPPYSCFCHECK = SimpleKeyword("sloppyscfcheck")
+    NOSLOPPYSCFCHECK = SimpleKeyword("nosloppyscfcheck")
+    SCFCHECKGRAD = SimpleKeyword("scfcheckgrad")
+    SCFCONV6 = SimpleKeyword("scfconv6")
+    SCFCONV7 = SimpleKeyword("scfconv7")
+    SCFCONV8 = SimpleKeyword("scfconv8")
+    SCFCONV9 = SimpleKeyword("scfconv9")
+    SCFCONV10 = SimpleKeyword("scfconv10")
+    SCFCONV11 = SimpleKeyword("scfconv11")
+    SCFCONV12 = SimpleKeyword("scfconv12")
+    EASYCONV = SimpleKeyword("easyconv")
+    NORMALCONV = SimpleKeyword("normalconv")
+    SLOWCONV = SimpleKeyword("slowconv")
+    VERYSLOWCONV = SimpleKeyword("veryslowconv")
+    DAMP = SimpleKeyword("damp")
+    NODAMP = SimpleKeyword("nodamp")
+    LSHIFT = SimpleKeyword("lshift")
+    NOLSHIFT = SimpleKeyword("nolshift")
+    USEINCREMENTAL = SimpleKeyword("useincremental")
+    NOINCREMENTAL = SimpleKeyword("noincremental")
+    NOITER = SimpleKeyword("noiter")
+    SCFLBFGS = SimpleKeyword("scflbfgs")
+    SCFLBOFILL = SimpleKeyword("scflbofill")
+    SCFLPOWELL = SimpleKeyword("scflpowell")
+    SCFLSR1 = SimpleKeyword("scflsr1")
+    NOTRAHRANDOMIZE = SimpleKeyword("notrahrandomize")

--- a/src/opi/input/simple_keywords/scf.py
+++ b/src/opi/input/simple_keywords/scf.py
@@ -7,231 +7,153 @@ __all__ = ("Scf",)
 
 
 class Scf(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Scf.
-
-    Attributes
-    ----------
-    G3CONV : SimpleKeyword
-        SCF solver combination
-    AODIISTRAH : SimpleKeyword
-        SCF solver combination
-    DIISTRAH : SimpleKeyword
-        SCF solver combination
-    KDIISTRAH : SimpleKeyword
-        SCF solver combination
-    DIIS : SimpleKeyword
-        SCF solver
-    NODIIS : SimpleKeyword
-        SCF solver
-    AODIIS : SimpleKeyword
-        SCF solver
-    NOAODIIS : SimpleKeyword
-        SCF solver
-    KDIIS : SimpleKeyword
-        SCF solver
-    NOKDIIS : SimpleKeyword
-        SCF solver
-    SOSCF : SimpleKeyword
-        SCF solver
-    NOSOSCF : SimpleKeyword
-        SCF solver
-    TRAH : SimpleKeyword
-        SCF solver
-    NOTRAH : SimpleKeyword
-        SCF solver
-    AUTOSTART : SimpleKeyword
-        SCF initial guess start SCF from a gbw file with the same basename (default)
-    NOAUTOSTART : SimpleKeyword
-        SCF initial guess do not start SCF from a gbw file with the same basename
-    MOREAD : SimpleKeyword
-        SCF initial guess read orbitals from gbw file
-    EHTANO : SimpleKeyword
-        SCF initial guess
-    HCORE : SimpleKeyword
-        SCF initial guess
-    HUECKEL : SimpleKeyword
-        SCF initial guess
-    PATOM : SimpleKeyword
-        SCF initial guess
-    PMODEL : SimpleKeyword
-        SCF initial guess
-    PMODELX : SimpleKeyword
-        SCF initial guess
-    PMODELXAV : SimpleKeyword
-        SCF initial guess
-    PMODELXPM : SimpleKeyword
-        SCF initial guess
-    SYMBREAKGUESS : SimpleKeyword
-        SCF initial guess
-    UNITMATRIXGUESS : SimpleKeyword
-        SCF initial guess
-    USEGRAMSCHMIDT : SimpleKeyword
-        SCF initial guess
-    CALCGUESSENERGY : SimpleKeyword
-        Calculate the guess energy
-    CONV : SimpleKeyword
-        Conventional SCF
-    SEMIDIRECT : SimpleKeyword
-        Semidirect SCF
-    DIRECT : SimpleKeyword
-        Direct SCF
-    SCFSTAB : SimpleKeyword
-        SCF stability analysis
-    NOSCFSTAB : SimpleKeyword
-        No SCF stability analysis
-    DELTASCF : SimpleKeyword
-        DeltaSCF for access to excited states
-    FRSOSCF : SimpleKeyword
-        freeze and release DeltaSCF settings
-    GMF : SimpleKeyword
-        DeltaSCF settings
-    SMEAR : SimpleKeyword
-        do finite temperature DFT (smearing)
-    NOSMEAR : SimpleKeyword
-        do not use finite temperature DFT (smearing)
-    FRACOCC : SimpleKeyword
-        enable fractional occupations
-    SCFCONVFORCED : SimpleKeyword
-        Force SCF convergence for subsequent operations
-    SLOPPYSCF : SimpleKeyword
-        SCF convergence threshold settings
-    LOOSESCF : SimpleKeyword
-        SCF convergence threshold settings
-    NORMALSCF : SimpleKeyword
-        SCF convergence threshold settings
-    STRONGSCF : SimpleKeyword
-        SCF convergence threshold settings
-    TIGHTSCF : SimpleKeyword
-        SCF convergence threshold settings
-    VERYTIGHTSCF : SimpleKeyword
-        SCF convergence threshold settings
-    EXTREMESCF : SimpleKeyword
-        SCF convergence threshold settings
-    SLOPPYSCFCHECK : SimpleKeyword
-        SCF convergence threshold settings
-    NOSLOPPYSCFCHECK : SimpleKeyword
-        SCF convergence threshold settings
-    SCFCHECKGRAD : SimpleKeyword
-        SCF convergence threshold settings
-    SCFCONV6 : SimpleKeyword
-        SCF convergence threshold settings
-    SCFCONV7 : SimpleKeyword
-        SCF convergence threshold settings
-    SCFCONV8 : SimpleKeyword
-        SCF convergence threshold settings
-    SCFCONV9 : SimpleKeyword
-        SCF convergence threshold settings
-    SCFCONV10 : SimpleKeyword
-        SCF convergence threshold settings
-    SCFCONV11 : SimpleKeyword
-        SCF convergence threshold settings
-    SCFCONV12 : SimpleKeyword
-        SCF convergence threshold settings
-    EASYCONV : SimpleKeyword
-        SCF convergence strategy
-    NORMALCONV : SimpleKeyword
-        SCF convergence strategy
-    SLOWCONV : SimpleKeyword
-        SCF convergence strategy
-    VERYSLOWCONV : SimpleKeyword
-        SCF convergence strategy
-    DAMP : SimpleKeyword
-        SCF settings
-    NODAMP : SimpleKeyword
-        SCF settings
-    LSHIFT : SimpleKeyword
-        SCF settings
-    NOLSHIFT : SimpleKeyword
-        SCF settings
-    USEINCREMENTAL : SimpleKeyword
-        SCF settings
-    NOINCREMENTAL : SimpleKeyword
-        SCF settings
-    NOITER : SimpleKeyword
-        SCF settings no iterations
-    SCFLBFGS : SimpleKeyword
-        SOSCF settings
-    SCFLBOFILL : SimpleKeyword
-        SOSCF settings
-    SCFLPOWELL : SimpleKeyword
-        SOSCF settings
-    SCFLSR1 : SimpleKeyword
-        SOSCF settings
-    NOTRAHRANDOMIZE : SimpleKeyword
-        TRAH settings
-    """
+    """Enum to store all simple keywords of type Scf."""
 
     G3CONV = SimpleKeyword("3conv")
+    """SimpleKeyword: SCF solver combination."""
     AODIISTRAH = SimpleKeyword("aodiistrah")
+    """SimpleKeyword: SCF solver combination."""
     DIISTRAH = SimpleKeyword("diistrah")
+    """SimpleKeyword: SCF solver combination."""
     KDIISTRAH = SimpleKeyword("kdiistrah")
+    """SimpleKeyword: SCF solver combination."""
     DIIS = SimpleKeyword("diis")
+    """SimpleKeyword: SCF solver."""
     NODIIS = SimpleKeyword("nodiis")
+    """SimpleKeyword: SCF solver."""
     AODIIS = SimpleKeyword("aodiis")
+    """SimpleKeyword: SCF solver."""
     NOAODIIS = SimpleKeyword("noaodiis")
+    """SimpleKeyword: SCF solver."""
     KDIIS = SimpleKeyword("kdiis")
+    """SimpleKeyword: SCF solver."""
     NOKDIIS = SimpleKeyword("nokdiis")
+    """SimpleKeyword: SCF solver."""
     SOSCF = SimpleKeyword("soscf")
+    """SimpleKeyword: SCF solver."""
     NOSOSCF = SimpleKeyword("nososcf")
+    """SimpleKeyword: SCF solver."""
     TRAH = SimpleKeyword("trah")
+    """SimpleKeyword: SCF solver."""
     NOTRAH = SimpleKeyword("notrah")
+    """SimpleKeyword: SCF solver."""
     AUTOSTART = SimpleKeyword("autostart")
+    """SimpleKeyword: SCF initial guess start SCF from a gbw file with the same basename (default)."""
     NOAUTOSTART = SimpleKeyword("noautostart")
+    """SimpleKeyword: SCF initial guess do not start SCF from a gbw file with the same basename."""
     MOREAD = SimpleKeyword("moread")
+    """SimpleKeyword: SCF initial guess read orbitals from gbw file."""
     EHTANO = SimpleKeyword("ehtano")
+    """SimpleKeyword: SCF initial guess."""
     HCORE = SimpleKeyword("hcore")
+    """SimpleKeyword: SCF initial guess."""
     HUECKEL = SimpleKeyword("hueckel")
+    """SimpleKeyword: SCF initial guess."""
     PATOM = SimpleKeyword("patom")
+    """SimpleKeyword: SCF initial guess."""
     PMODEL = SimpleKeyword("pmodel")
+    """SimpleKeyword: SCF initial guess."""
     PMODELX = SimpleKeyword("pmodelx")
+    """SimpleKeyword: SCF initial guess."""
     PMODELXAV = SimpleKeyword("pmodelxav")
+    """SimpleKeyword: SCF initial guess."""
     PMODELXPM = SimpleKeyword("pmodelxpm")
+    """SimpleKeyword: SCF initial guess."""
     SYMBREAKGUESS = SimpleKeyword("symbreakguess")
+    """SimpleKeyword: SCF initial guess."""
     UNITMATRIXGUESS = SimpleKeyword("unitmatrixguess")
+    """SimpleKeyword: SCF initial guess."""
     USEGRAMSCHMIDT = SimpleKeyword("usegramschmidt")
+    """SimpleKeyword: SCF initial guess."""
     CALCGUESSENERGY = SimpleKeyword("calcguessenergy")
+    """SimpleKeyword: Calculate the guess energy."""
     CONV = SimpleKeyword("conv")
+    """SimpleKeyword: Conventional SCF."""
     SEMIDIRECT = SimpleKeyword("semidirect")
+    """SimpleKeyword: Semidirect SCF."""
     DIRECT = SimpleKeyword("direct")
+    """SimpleKeyword: Direct SCF."""
     SCFSTAB = SimpleKeyword("scfstab")
+    """SimpleKeyword: SCF stability analysis."""
     NOSCFSTAB = SimpleKeyword("noscfstab")
+    """SimpleKeyword: No SCF stability analysis."""
     DELTASCF = SimpleKeyword("deltascf")
+    """SimpleKeyword: DeltaSCF for access to excited states."""
     FRSOSCF = SimpleKeyword("frsoscf")
+    """SimpleKeyword: freeze and release DeltaSCF settings."""
     GMF = SimpleKeyword("gmf")
+    """SimpleKeyword: DeltaSCF settings."""
     SMEAR = SimpleKeyword("smear")
+    """SimpleKeyword: do finite temperature DFT (smearing)."""
     NOSMEAR = SimpleKeyword("nosmear")
+    """SimpleKeyword: do not use finite temperature DFT (smearing)."""
     FRACOCC = SimpleKeyword("fracocc")
+    """SimpleKeyword: enable fractional occupations."""
     SCFCONVFORCED = SimpleKeyword("scfconvforced")
+    """SimpleKeyword: Force SCF convergence for subsequent operations."""
     SLOPPYSCF = SimpleKeyword("sloppyscf")
+    """SimpleKeyword: SCF convergence threshold settings."""
     LOOSESCF = SimpleKeyword("loosescf")
+    """SimpleKeyword: SCF convergence threshold settings."""
     NORMALSCF = SimpleKeyword("normalscf")
+    """SimpleKeyword: SCF convergence threshold settings."""
     STRONGSCF = SimpleKeyword("strongscf")
+    """SimpleKeyword: SCF convergence threshold settings."""
     TIGHTSCF = SimpleKeyword("tightscf")
+    """SimpleKeyword: SCF convergence threshold settings."""
     VERYTIGHTSCF = SimpleKeyword("verytightscf")
+    """SimpleKeyword: SCF convergence threshold settings."""
     EXTREMESCF = SimpleKeyword("extremescf")
+    """SimpleKeyword: SCF convergence threshold settings."""
     SLOPPYSCFCHECK = SimpleKeyword("sloppyscfcheck")
+    """SimpleKeyword: SCF convergence threshold settings."""
     NOSLOPPYSCFCHECK = SimpleKeyword("nosloppyscfcheck")
+    """SimpleKeyword: SCF convergence threshold settings."""
     SCFCHECKGRAD = SimpleKeyword("scfcheckgrad")
+    """SimpleKeyword: SCF convergence threshold settings."""
     SCFCONV6 = SimpleKeyword("scfconv6")
+    """SimpleKeyword: SCF convergence threshold settings."""
     SCFCONV7 = SimpleKeyword("scfconv7")
+    """SimpleKeyword: SCF convergence threshold settings."""
     SCFCONV8 = SimpleKeyword("scfconv8")
+    """SimpleKeyword: SCF convergence threshold settings."""
     SCFCONV9 = SimpleKeyword("scfconv9")
+    """SimpleKeyword: SCF convergence threshold settings."""
     SCFCONV10 = SimpleKeyword("scfconv10")
+    """SimpleKeyword: SCF convergence threshold settings."""
     SCFCONV11 = SimpleKeyword("scfconv11")
+    """SimpleKeyword: SCF convergence threshold settings."""
     SCFCONV12 = SimpleKeyword("scfconv12")
+    """SimpleKeyword: SCF convergence threshold settings."""
     EASYCONV = SimpleKeyword("easyconv")
+    """SimpleKeyword: SCF convergence strategy."""
     NORMALCONV = SimpleKeyword("normalconv")
+    """SimpleKeyword: SCF convergence strategy."""
     SLOWCONV = SimpleKeyword("slowconv")
+    """SimpleKeyword: SCF convergence strategy."""
     VERYSLOWCONV = SimpleKeyword("veryslowconv")
+    """SimpleKeyword: SCF convergence strategy."""
     DAMP = SimpleKeyword("damp")
+    """SimpleKeyword: SCF settings."""
     NODAMP = SimpleKeyword("nodamp")
+    """SimpleKeyword: SCF settings."""
     LSHIFT = SimpleKeyword("lshift")
+    """SimpleKeyword: SCF settings."""
     NOLSHIFT = SimpleKeyword("nolshift")
+    """SimpleKeyword: SCF settings."""
     USEINCREMENTAL = SimpleKeyword("useincremental")
+    """SimpleKeyword: SCF settings."""
     NOINCREMENTAL = SimpleKeyword("noincremental")
+    """SimpleKeyword: SCF settings."""
     NOITER = SimpleKeyword("noiter")
+    """SimpleKeyword: SCF settings no iterations."""
     SCFLBFGS = SimpleKeyword("scflbfgs")
+    """SimpleKeyword: SOSCF settings."""
     SCFLBOFILL = SimpleKeyword("scflbofill")
+    """SimpleKeyword: SOSCF settings."""
     SCFLPOWELL = SimpleKeyword("scflpowell")
+    """SimpleKeyword: SOSCF settings."""
     SCFLSR1 = SimpleKeyword("scflsr1")
+    """SimpleKeyword: SOSCF settings."""
     NOTRAHRANDOMIZE = SimpleKeyword("notrahrandomize")
+    """SimpleKeyword: TRAH settings."""

--- a/src/opi/input/simple_keywords/shell_type.py
+++ b/src/opi/input/simple_keywords/shell_type.py
@@ -7,30 +7,19 @@ __all__ = ("ShellType",)
 
 
 class ShellType(SimpleKeywordBox):
-    """Enum to store all simple keywords of type ShellType.
-
-    Attributes
-    ----------
-    RHF : SimpleKeyword
-        Type of the wavefunction: restricted, unrestricted, multireference
-    RKS : SimpleKeyword
-        Type of the wavefunction: restricted, unrestricted, multireference
-    ROHF : SimpleKeyword
-        Type of the wavefunction: restricted, unrestricted, multireference
-    ROKS : SimpleKeyword
-        Type of the wavefunction: restricted, unrestricted, multireference
-    UHF : SimpleKeyword
-        Type of the wavefunction: restricted, unrestricted, multireference
-    UKS : SimpleKeyword
-        Type of the wavefunction: restricted, unrestricted, multireference
-    CASSCF : SimpleKeyword
-        Type of the wavefunction: restricted, unrestricted, multireference
-    """
+    """Enum to store all simple keywords of type ShellType."""
 
     RHF = SimpleKeyword("rhf")
+    """SimpleKeyword: Type of the wavefunction: restricted, unrestricted, multireference."""
     RKS = SimpleKeyword("rks")
+    """SimpleKeyword: Type of the wavefunction: restricted, unrestricted, multireference."""
     ROHF = SimpleKeyword("rohf")
+    """SimpleKeyword: Type of the wavefunction: restricted, unrestricted, multireference."""
     ROKS = SimpleKeyword("roks")
+    """SimpleKeyword: Type of the wavefunction: restricted, unrestricted, multireference."""
     UHF = SimpleKeyword("uhf")
+    """SimpleKeyword: Type of the wavefunction: restricted, unrestricted, multireference."""
     UKS = SimpleKeyword("uks")
+    """SimpleKeyword: Type of the wavefunction: restricted, unrestricted, multireference."""
     CASSCF = SimpleKeyword("casscf")
+    """SimpleKeyword: Type of the wavefunction: restricted, unrestricted, multireference."""

--- a/src/opi/input/simple_keywords/shell_type.py
+++ b/src/opi/input/simple_keywords/shell_type.py
@@ -7,18 +7,30 @@ __all__ = ("ShellType",)
 
 
 class ShellType(SimpleKeywordBox):
-    """Enum to store all simple keywords of type ShellType"""
+    """Enum to store all simple keywords of type ShellType.
 
-    RHF = SimpleKeyword("rhf")  # Type of the wavefunction: restricted, unrestricted, multireference
-    RKS = SimpleKeyword("rks")  # Type of the wavefunction: restricted, unrestricted, multireference
-    ROHF = SimpleKeyword(
-        "rohf"
-    )  # Type of the wavefunction: restricted, unrestricted, multireference
-    ROKS = SimpleKeyword(
-        "roks"
-    )  # Type of the wavefunction: restricted, unrestricted, multireference
-    UHF = SimpleKeyword("uhf")  # Type of the wavefunction: restricted, unrestricted, multireference
-    UKS = SimpleKeyword("uks")  # Type of the wavefunction: restricted, unrestricted, multireference
-    CASSCF = SimpleKeyword(
-        "casscf"
-    )  # Type of the wavefunction: restricted, unrestricted, multireference
+    Attributes
+    ----------
+    RHF : SimpleKeyword
+        Type of the wavefunction: restricted, unrestricted, multireference
+    RKS : SimpleKeyword
+        Type of the wavefunction: restricted, unrestricted, multireference
+    ROHF : SimpleKeyword
+        Type of the wavefunction: restricted, unrestricted, multireference
+    ROKS : SimpleKeyword
+        Type of the wavefunction: restricted, unrestricted, multireference
+    UHF : SimpleKeyword
+        Type of the wavefunction: restricted, unrestricted, multireference
+    UKS : SimpleKeyword
+        Type of the wavefunction: restricted, unrestricted, multireference
+    CASSCF : SimpleKeyword
+        Type of the wavefunction: restricted, unrestricted, multireference
+    """
+
+    RHF = SimpleKeyword("rhf")
+    RKS = SimpleKeyword("rks")
+    ROHF = SimpleKeyword("rohf")
+    ROKS = SimpleKeyword("roks")
+    UHF = SimpleKeyword("uhf")
+    UKS = SimpleKeyword("uks")
+    CASSCF = SimpleKeyword("casscf")

--- a/src/opi/input/simple_keywords/solvation.py
+++ b/src/opi/input/simple_keywords/solvation.py
@@ -7,8 +7,18 @@ __all__ = ("Solvation",)
 
 
 class Solvation(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Solvation"""
+    """Enum to store all simple keywords of type Solvation.
 
-    DRACO = SimpleKeyword("draco")  # apply dynamic charge dependent scaling of the solvation radii
-    ECRISM = SimpleKeyword("ecrism")  # Use ecrism solvation model
-    SMD18 = SimpleKeyword("smd18")  # Use refinde SMD18 model with different radii for Br and I
+    Attributes
+    ----------
+    DRACO : SimpleKeyword
+        apply dynamic charge dependent scaling of the solvation radii
+    ECRISM : SimpleKeyword
+        Use ecrism solvation model
+    SMD18 : SimpleKeyword
+        Use refinde SMD18 model with different radii for Br and I
+    """
+
+    DRACO = SimpleKeyword("draco")
+    ECRISM = SimpleKeyword("ecrism")
+    SMD18 = SimpleKeyword("smd18")

--- a/src/opi/input/simple_keywords/solvation.py
+++ b/src/opi/input/simple_keywords/solvation.py
@@ -7,18 +7,11 @@ __all__ = ("Solvation",)
 
 
 class Solvation(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Solvation.
-
-    Attributes
-    ----------
-    DRACO : SimpleKeyword
-        apply dynamic charge dependent scaling of the solvation radii
-    ECRISM : SimpleKeyword
-        Use ecrism solvation model
-    SMD18 : SimpleKeyword
-        Use refinde SMD18 model with different radii for Br and I
-    """
+    """Enum to store all simple keywords of type Solvation."""
 
     DRACO = SimpleKeyword("draco")
+    """SimpleKeyword: apply dynamic charge dependent scaling of the solvation radii."""
     ECRISM = SimpleKeyword("ecrism")
+    """SimpleKeyword: Use ecrism solvation model."""
     SMD18 = SimpleKeyword("smd18")
+    """SimpleKeyword: Use refinde SMD18 model with different radii for Br and I."""

--- a/src/opi/input/simple_keywords/sqm.py
+++ b/src/opi/input/simple_keywords/sqm.py
@@ -7,63 +7,41 @@ __all__ = ("Sqm",)
 
 
 class Sqm(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Sqm.
-
-    Attributes
-    ----------
-    AM1 : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    GFN0_XTB : SimpleKeyword
-        GFN0-xTB also known as XTB0
-    GFN1_XTB : SimpleKeyword
-        GFN1-xTB also known as GFN-xTB or XTB1
-    GFN2_XTB : SimpleKeyword
-        GFN2-xTB also known as XTB or XTB2
-    MNDO : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    NATIVE_GFN1_XTB : SimpleKeyword
-        Native GFN1-xTB also known as GFN-xTB or XTB1
-    NATIVE_GFN2_XTB : SimpleKeyword
-        Native GFN2-xTB also known as XTB or XTB2
-    NDDO_1 : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    NDDO_2 : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    NDDO_MK : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    NONOTCH : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    NOTCH : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    PM3 : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    ZINDO_1 : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    ZINDO_2 : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    ZINDO_S : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    ZNDDO_1 : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    ZNDDO_2 : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
-    """
+    """Enum to store all simple keywords of type Sqm."""
 
     AM1 = SimpleKeyword("am1")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     GFN0_XTB = SimpleKeyword("gfn0-xtb")
+    """SimpleKeyword: GFN0-xTB also known as XTB0."""
     GFN1_XTB = SimpleKeyword("gfn1-xtb")
+    """SimpleKeyword: GFN1-xTB also known as GFN-xTB or XTB1."""
     GFN2_XTB = SimpleKeyword("gfn2-xtb")
+    """SimpleKeyword: GFN2-xTB also known as XTB or XTB2."""
     MNDO = SimpleKeyword("mndo")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     NATIVE_GFN1_XTB = SimpleKeyword("native-gfn1-xtb")
+    """SimpleKeyword: Native GFN1-xTB also known as GFN-xTB or XTB1."""
     NATIVE_GFN2_XTB = SimpleKeyword("native-gfn2-xtb")
+    """SimpleKeyword: Native GFN2-xTB also known as XTB or XTB2."""
     NDDO_1 = SimpleKeyword("nddo/1")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     NDDO_2 = SimpleKeyword("nddo/2")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     NDDO_MK = SimpleKeyword("nddo/mk")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     NONOTCH = SimpleKeyword("nonotch")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     NOTCH = SimpleKeyword("notch")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     PM3 = SimpleKeyword("pm3")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     ZINDO_1 = SimpleKeyword("zindo/1")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     ZINDO_2 = SimpleKeyword("zindo/2")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     ZINDO_S = SimpleKeyword("zindo/s")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     ZNDDO_1 = SimpleKeyword("znddo/1")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""
     ZNDDO_2 = SimpleKeyword("znddo/2")
+    """SimpleKeyword: SQM: Semiempirical quantum mechanical methods."""

--- a/src/opi/input/simple_keywords/sqm.py
+++ b/src/opi/input/simple_keywords/sqm.py
@@ -7,27 +7,63 @@ __all__ = ("Sqm",)
 
 
 class Sqm(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Sqm"""
+    """Enum to store all simple keywords of type Sqm.
 
-    AM1 = SimpleKeyword("am1")  # SQM: Semiempirical quantum mechanical methods
-    GFN0_XTB = SimpleKeyword("gfn0-xtb")  # GFN0-xTB also known as XTB0
-    GFN1_XTB = SimpleKeyword("gfn1-xtb")  # GFN1-xTB also known as GFN-xTB or XTB1
-    GFN2_XTB = SimpleKeyword("gfn2-xtb")  # GFN1-xTB also known as XTB or XTB2
-    MNDO = SimpleKeyword("mndo")  # SQM: Semiempirical quantum mechanical methods
-    NATIVE_GFN1_XTB = SimpleKeyword(
-        "native-gfn1-xtb"
-    )  # SQM: Semiempirical quantum mechanical methods
-    NATIVE_GFN2_XTB = SimpleKeyword(
-        "native-gfn2-xtb"
-    )  # SQM: Semiempirical quantum mechanical methods
-    NDDO_1 = SimpleKeyword("nddo/1")  # SQM: Semiempirical quantum mechanical methods
-    NDDO_2 = SimpleKeyword("nddo/2")  # SQM: Semiempirical quantum mechanical methods
-    NDDO_MK = SimpleKeyword("nddo/mk")  # SQM: Semiempirical quantum mechanical methods
-    NONOTCH = SimpleKeyword("nonotch")  # SQM: Semiempirical quantum mechanical methods
-    NOTCH = SimpleKeyword("notch")  # SQM: Semiempirical quantum mechanical methods
-    PM3 = SimpleKeyword("pm3")  # SQM: Semiempirical quantum mechanical methods
-    ZINDO_1 = SimpleKeyword("zindo/1")  # SQM: Semiempirical quantum mechanical methods
-    ZINDO_2 = SimpleKeyword("zindo/2")  # SQM: Semiempirical quantum mechanical methods
-    ZINDO_S = SimpleKeyword("zindo/s")  # SQM: Semiempirical quantum mechanical methods
-    ZNDDO_1 = SimpleKeyword("znddo/1")  # SQM: Semiempirical quantum mechanical methods
-    ZNDDO_2 = SimpleKeyword("znddo/2")  # SQM: Semiempirical quantum mechanical methods
+    Attributes
+    ----------
+    AM1 : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    GFN0_XTB : SimpleKeyword
+        GFN0-xTB also known as XTB0
+    GFN1_XTB : SimpleKeyword
+        GFN1-xTB also known as GFN-xTB or XTB1
+    GFN2_XTB : SimpleKeyword
+        GFN1-xTB also known as XTB or XTB2
+    MNDO : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    NATIVE_GFN1_XTB : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    NATIVE_GFN2_XTB : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    NDDO_1 : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    NDDO_2 : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    NDDO_MK : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    NONOTCH : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    NOTCH : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    PM3 : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    ZINDO_1 : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    ZINDO_2 : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    ZINDO_S : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    ZNDDO_1 : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    ZNDDO_2 : SimpleKeyword
+        SQM: Semiempirical quantum mechanical methods
+    """
+
+    AM1 = SimpleKeyword("am1")
+    GFN0_XTB = SimpleKeyword("gfn0-xtb")
+    GFN1_XTB = SimpleKeyword("gfn1-xtb")
+    GFN2_XTB = SimpleKeyword("gfn2-xtb")
+    MNDO = SimpleKeyword("mndo")
+    NATIVE_GFN1_XTB = SimpleKeyword("native-gfn1-xtb")
+    NATIVE_GFN2_XTB = SimpleKeyword("native-gfn2-xtb")
+    NDDO_1 = SimpleKeyword("nddo/1")
+    NDDO_2 = SimpleKeyword("nddo/2")
+    NDDO_MK = SimpleKeyword("nddo/mk")
+    NONOTCH = SimpleKeyword("nonotch")
+    NOTCH = SimpleKeyword("notch")
+    PM3 = SimpleKeyword("pm3")
+    ZINDO_1 = SimpleKeyword("zindo/1")
+    ZINDO_2 = SimpleKeyword("zindo/2")
+    ZINDO_S = SimpleKeyword("zindo/s")
+    ZNDDO_1 = SimpleKeyword("znddo/1")
+    ZNDDO_2 = SimpleKeyword("znddo/2")

--- a/src/opi/input/simple_keywords/sqm.py
+++ b/src/opi/input/simple_keywords/sqm.py
@@ -18,13 +18,13 @@ class Sqm(SimpleKeywordBox):
     GFN1_XTB : SimpleKeyword
         GFN1-xTB also known as GFN-xTB or XTB1
     GFN2_XTB : SimpleKeyword
-        GFN1-xTB also known as XTB or XTB2
+        GFN2-xTB also known as XTB or XTB2
     MNDO : SimpleKeyword
         SQM: Semiempirical quantum mechanical methods
     NATIVE_GFN1_XTB : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
+        Native GFN1-xTB also known as GFN-xTB or XTB1
     NATIVE_GFN2_XTB : SimpleKeyword
-        SQM: Semiempirical quantum mechanical methods
+        Native GFN2-xTB also known as XTB or XTB2
     NDDO_1 : SimpleKeyword
         SQM: Semiempirical quantum mechanical methods
     NDDO_2 : SimpleKeyword

--- a/src/opi/input/simple_keywords/task.py
+++ b/src/opi/input/simple_keywords/task.py
@@ -7,60 +7,39 @@ __all__ = ("Task",)
 
 
 class Task(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Task.
-
-    Attributes
-    ----------
-    SP : SimpleKeyword
-        Perform a single point energy calculation (default)
-    ENGRAD : SimpleKeyword
-        Energy and gradient
-    OPT : SimpleKeyword
-        Perform a geometry optimization
-    FREQ : SimpleKeyword
-        Analytical frequency calculation
-    NUMFREQ : SimpleKeyword
-        Numerical frequency calculation
-    MD : SimpleKeyword
-        Molecular dynamics
-    EDA : SimpleKeyword
-        Perform an energy decomposition analysis (EDA)
-    AUTOFRAG : SimpleKeyword
-        Automatic detection of fragments.
-    CIM : SimpleKeyword
-        Calculate energy with clusters in molecule approach.
-    SOLVATOR : SimpleKeyword
-        Use the solvator for explicit solvation
-    ENMGRAD : SimpleKeyword
-        Energy normal mode gradient
-    CALCESTHESS : SimpleKeyword
-        Calculate an approximate hessian
-    MT : SimpleKeyword
-        mode trajectory
-    NMSCAN : SimpleKeyword
-        normal mode scan
-    PRINTTHERMOCHEM : SimpleKeyword
-        Only do thermostatistical corrections
-    PROPERTIESONLY : SimpleKeyword
-        Only calc properties
-    NUMNAC : SimpleKeyword
-        Numerical non-adiabatic coupling
-    """
+    """Enum to store all simple keywords of type Task."""
 
     SP = SimpleKeyword("sp")
+    """SimpleKeyword: Perform a single point energy calculation (default)."""
     ENGRAD = SimpleKeyword("engrad")
+    """SimpleKeyword: Energy and gradient."""
     OPT = SimpleKeyword("opt")
+    """SimpleKeyword: Perform a geometry optimization."""
     FREQ = SimpleKeyword("freq")
+    """SimpleKeyword: Analytical frequency calculation."""
     NUMFREQ = SimpleKeyword("numfreq")
+    """SimpleKeyword: Numerical frequency calculation."""
     MD = SimpleKeyword("md")
+    """SimpleKeyword: Molecular dynamics."""
     EDA = SimpleKeyword("eda")
+    """SimpleKeyword: Perform an energy decomposition analysis (EDA)."""
     AUTOFRAG = SimpleKeyword("autofrag")
+    """SimpleKeyword: Automatic detection of fragments.."""
     CIM = SimpleKeyword("cim")
+    """SimpleKeyword: Calculate energy with clusters in molecule approach.."""
     SOLVATOR = SimpleKeyword("solvator")
+    """SimpleKeyword: Use the solvator for explicit solvation."""
     ENMGRAD = SimpleKeyword("enmgrad")
+    """SimpleKeyword: Energy normal mode gradient."""
     CALCESTHESS = SimpleKeyword("calcesthess")
+    """SimpleKeyword: Calculate an approximate hessian."""
     MT = SimpleKeyword("mt")
+    """SimpleKeyword: mode trajectory."""
     NMSCAN = SimpleKeyword("nmscan")
+    """SimpleKeyword: normal mode scan."""
     PRINTTHERMOCHEM = SimpleKeyword("printthermochem")
+    """SimpleKeyword: Only do thermostatistical corrections."""
     PROPERTIESONLY = SimpleKeyword("propertiesonly")
+    """SimpleKeyword: Only calc properties."""
     NUMNAC = SimpleKeyword("numnac")
+    """SimpleKeyword: Numerical non-adiabatic coupling."""

--- a/src/opi/input/simple_keywords/task.py
+++ b/src/opi/input/simple_keywords/task.py
@@ -12,143 +12,23 @@ class Task(SimpleKeywordBox):
     Attributes
     ----------
     SP : SimpleKeyword
-        perform a single point energy calculation (default)
+        Perform a single point energy calculation (default)
     ENGRAD : SimpleKeyword
         Energy and gradient
     OPT : SimpleKeyword
-        Perform geometry optimization
+        Perform a geometry optimization
     FREQ : SimpleKeyword
-        analytical frequency calculation
+        Analytical frequency calculation
     NUMFREQ : SimpleKeyword
-        numerical frequency calculation
+        Numerical frequency calculation
     MD : SimpleKeyword
-        molecular dynamics
+        Molecular dynamics
     EDA : SimpleKeyword
-        Perform an eda analysis
+        Perform an energy decomposition analysis (EDA)
     AUTOFRAG : SimpleKeyword
-        Automatic detection of fragments
+        Automatic detection of fragments.
     CIM : SimpleKeyword
-        Calculate energy with clusters in molecule approach
-    CRUDEOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    LOOSEOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    NORMALOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    SLOPPYOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    TIGHTOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    VERYTIGHTOPT : SimpleKeyword
-        Geometry optimization with thresholds
-    OPTH : SimpleKeyword
-        Optimize only hydrogen atoms
-    COPT : SimpleKeyword
-        Perform geometry optimization (cartesian coordinates)
-    L_OPT : SimpleKeyword
-        Perform geometry optimization with lopt
-    L_OPTH : SimpleKeyword
-        Optimize only hydrogen atoms
-    EXTOPT : SimpleKeyword
-        Use only the geometry optimizer from orca with external energy/gradient
-    OPTTS : SimpleKeyword
-        optimize transition state
-    OPTTS_GMF : SimpleKeyword
-        optimize transition state
-    QMMMOPT : SimpleKeyword
-        Optimize the geometry with qmmm
-    QMMMOPT_PDYNAMO : SimpleKeyword
-        Optimize the geometry with qmmm
-    RIGIDBODYOPT : SimpleKeyword
-        Optimize fragments as rigid bodies
-    CI_OPT : SimpleKeyword
-        conical-intersection optimization
-    MECP_OPT : SimpleKeyword
-        MECP optimization
-    NEB : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    NEB_CI : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    NEB_IDPP : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    NEB_MMFTS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    FAST_NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    LOOSE_NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    TIGHT_NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB_CI : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    FLAT_NEB_TS : SimpleKeyword
-        NEB for finding minimal energy pathways (and transition states)
-    IRC : SimpleKeyword
-        internal reaction coordinate
-    SCANTS : SimpleKeyword
-        scan for transition state
-    GOAT : SimpleKeyword
-        GOAT Methods
-    GOAT_COARSE : SimpleKeyword
-        GOAT Methods
-    GOAT_DIVERSITY : SimpleKeyword
-        GOAT Methods
-    GOAT_ENTROPY : SimpleKeyword
-        GOAT Methods
-    GOAT_EXPLORE : SimpleKeyword
-        GOAT Methods
-    GOAT_REACT : SimpleKeyword
-        GOAT Methods
-    GOAT_TS : SimpleKeyword
-        GOAT Methods
-    NORMALDOCK : SimpleKeyword
-        Docker Methods
-    COMPLETEDOCK : SimpleKeyword
-        Docker Methods
-    DOCK_GFN_FF : SimpleKeyword
-        Docker Methods
-    DOCK_GFN0_XTB : SimpleKeyword
-        Docker Methods
-    DOCK_GFN1_XTB : SimpleKeyword
-        Docker Methods
-    DOCK_GFN2_XTB : SimpleKeyword
-        Docker Methods
-    DOCK_GFNFF : SimpleKeyword
-        Docker Methods
-    DOCK_XTB : SimpleKeyword
-        Docker Methods
-    DOCK_XTB0 : SimpleKeyword
-        Docker Methods
-    DOCK_XTB1 : SimpleKeyword
-        Docker Methods
-    DOCKER : SimpleKeyword
-        Docker Methods
-    DOCKER_GFN_FF : SimpleKeyword
-        Docker Methods
-    DOCKER_GFN0_XTB : SimpleKeyword
-        Docker Methods
-    DOCKER_GFN1_XTB : SimpleKeyword
-        Docker Methods
-    DOCKER_GFN2_XTB : SimpleKeyword
-        Docker Methods
-    DOCKER_GFNFF : SimpleKeyword
-        Docker Methods
-    DOCKER_XTB : SimpleKeyword
-        Docker Methods
-    DOCKER_XTB0 : SimpleKeyword
-        Docker Methods
-    DOCKER_XTB1 : SimpleKeyword
-        Docker Methods
-    QUICKDOCK : SimpleKeyword
-        Docker Methods
-    SCREENDOCK : SimpleKeyword
-        Docker Methods
+        Calculate energy with clusters in molecule approach.
     SOLVATOR : SimpleKeyword
         Use the solvator for explicit solvation
     ENMGRAD : SimpleKeyword
@@ -176,66 +56,6 @@ class Task(SimpleKeywordBox):
     EDA = SimpleKeyword("eda")
     AUTOFRAG = SimpleKeyword("autofrag")
     CIM = SimpleKeyword("cim")
-    CRUDEOPT = SimpleKeyword("crudeopt")
-    LOOSEOPT = SimpleKeyword("looseopt")
-    NORMALOPT = SimpleKeyword("normalopt")
-    SLOPPYOPT = SimpleKeyword("sloppyopt")
-    TIGHTOPT = SimpleKeyword("tightopt")
-    VERYTIGHTOPT = SimpleKeyword("verytightopt")
-    OPTH = SimpleKeyword("opth")
-    COPT = SimpleKeyword("copt")
-    L_OPT = SimpleKeyword("l-opt")
-    L_OPTH = SimpleKeyword("l-opth")
-    EXTOPT = SimpleKeyword("extopt")
-    OPTTS = SimpleKeyword("optts")
-    OPTTS_GMF = SimpleKeyword("optts(gmf)")
-    QMMMOPT = SimpleKeyword("qmmmopt")
-    QMMMOPT_PDYNAMO = SimpleKeyword("qmmmopt/pdynamo")
-    RIGIDBODYOPT = SimpleKeyword("rigidbodyopt")
-    CI_OPT = SimpleKeyword("ci-opt")
-    MECP_OPT = SimpleKeyword("mecp-opt")
-    NEB = SimpleKeyword("neb")
-    NEB_CI = SimpleKeyword("neb-ci")
-    NEB_IDPP = SimpleKeyword("neb-idpp")
-    NEB_MMFTS = SimpleKeyword("neb-mmfts")
-    NEB_TS = SimpleKeyword("neb-ts")
-    FAST_NEB_TS = SimpleKeyword("fast-neb-ts")
-    LOOSE_NEB_TS = SimpleKeyword("loose-neb-ts")
-    TIGHT_NEB_TS = SimpleKeyword("tight-neb-ts")
-    ZOOM_NEB = SimpleKeyword("zoom-neb")
-    ZOOM_NEB_CI = SimpleKeyword("zoom-neb-ci")
-    ZOOM_NEB_TS = SimpleKeyword("zoom-neb-ts")
-    FLAT_NEB_TS = SimpleKeyword("flat-neb-ts")
-    IRC = SimpleKeyword("irc")
-    SCANTS = SimpleKeyword("scants")
-    GOAT = SimpleKeyword("goat")
-    GOAT_COARSE = SimpleKeyword("goat-coarse")
-    GOAT_DIVERSITY = SimpleKeyword("goat-diversity")
-    GOAT_ENTROPY = SimpleKeyword("goat-entropy")
-    GOAT_EXPLORE = SimpleKeyword("goat-explore")
-    GOAT_REACT = SimpleKeyword("goat-react")
-    GOAT_TS = SimpleKeyword("goat-ts")
-    NORMALDOCK = SimpleKeyword("normaldock")
-    COMPLETEDOCK = SimpleKeyword("completedock")
-    DOCK_GFN_FF = SimpleKeyword("dock(gfn-ff)")
-    DOCK_GFN0_XTB = SimpleKeyword("dock(gfn0-xtb)")
-    DOCK_GFN1_XTB = SimpleKeyword("dock(gfn1-xtb)")
-    DOCK_GFN2_XTB = SimpleKeyword("dock(gfn2-xtb)")
-    DOCK_GFNFF = SimpleKeyword("dock(gfnff)")
-    DOCK_XTB = SimpleKeyword("dock(xtb)")
-    DOCK_XTB0 = SimpleKeyword("dock(xtb0)")
-    DOCK_XTB1 = SimpleKeyword("dock(xtb1)")
-    DOCKER = SimpleKeyword("docker")
-    DOCKER_GFN_FF = SimpleKeyword("docker(gfn-ff)")
-    DOCKER_GFN0_XTB = SimpleKeyword("docker(gfn0-xtb)")
-    DOCKER_GFN1_XTB = SimpleKeyword("docker(gfn1-xtb)")
-    DOCKER_GFN2_XTB = SimpleKeyword("docker(gfn2-xtb)")
-    DOCKER_GFNFF = SimpleKeyword("docker(gfnff)")
-    DOCKER_XTB = SimpleKeyword("docker(xtb)")
-    DOCKER_XTB0 = SimpleKeyword("docker(xtb0)")
-    DOCKER_XTB1 = SimpleKeyword("docker(xtb1)")
-    QUICKDOCK = SimpleKeyword("quickdock")
-    SCREENDOCK = SimpleKeyword("screendock")
     SOLVATOR = SimpleKeyword("solvator")
     ENMGRAD = SimpleKeyword("enmgrad")
     CALCESTHESS = SimpleKeyword("calcesthess")

--- a/src/opi/input/simple_keywords/task.py
+++ b/src/opi/input/simple_keywords/task.py
@@ -7,106 +7,240 @@ __all__ = ("Task",)
 
 
 class Task(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Task"""
+    """Enum to store all simple keywords of type Task.
 
-    SP = SimpleKeyword("sp")  # perform a single point energy calculation (default)
-    ENGRAD = SimpleKeyword("engrad")  # Energy and gradient
-    OPT = SimpleKeyword("opt")  # Perform geometry optimization
-    FREQ = SimpleKeyword("freq")  # analytical frequency calculation
-    NUMFREQ = SimpleKeyword("numfreq")  # numerical frequency calculation
-    MD = SimpleKeyword("md")  # molecular dynamics
-    EDA = SimpleKeyword("eda")  # Perform an eda analysis
-    AUTOFRAG = SimpleKeyword("autofrag")  # Automatic detection of fragments
-    CIM = SimpleKeyword("cim")  # Calculate energy with clusters in molecule approach
-    CRUDEOPT = SimpleKeyword("crudeopt")  # Geometry optimization with thresholds
-    LOOSEOPT = SimpleKeyword("looseopt")  # Geometry optimization with thresholds
-    NORMALOPT = SimpleKeyword("normalopt")  # Geometry optimization with thresholds
-    SLOPPYOPT = SimpleKeyword("sloppyopt")  # Geometry optimization with thresholds
-    TIGHTOPT = SimpleKeyword("tightopt")  # Geometry optimization with thresholds
-    VERYTIGHTOPT = SimpleKeyword("verytightopt")  # Geometry optimization with thresholds
-    OPTH = SimpleKeyword("opth")  # Optimize only hydrogen atoms
-    COPT = SimpleKeyword("copt")  # Perform geometry optimization (cartesian coordinates)
-    L_OPT = SimpleKeyword("l-opt")  # Perform geometry optimization with lopt
-    L_OPTH = SimpleKeyword("l-opth")  # Optimize only hydrogen atoms
-    EXTOPT = SimpleKeyword(
-        "extopt"
-    )  # Use only the geometry optimizer from orca with external energy/gradient
-    OPTTS = SimpleKeyword("optts")  # optimize transition state
-    OPTTS_GMF = SimpleKeyword("optts(gmf)")  # optimize transition state
-    QMMMOPT = SimpleKeyword("qmmmopt")  # Optimize the geometry with qmmm
-    QMMMOPT_PDYNAMO = SimpleKeyword("qmmmopt/pdynamo")  # Optimize the geometry with qmmm
-    RIGIDBODYOPT = SimpleKeyword("rigidbodyopt")  # Optimize fragments as rigid bodies
-    CI_OPT = SimpleKeyword("ci-opt")  # conical-intersection optimization
-    MECP_OPT = SimpleKeyword("mecp-opt")  # MECP optimization
-    NEB = SimpleKeyword("neb")  # NEB for finding minimal energy pathways (and transition states)
-    NEB_CI = SimpleKeyword(
-        "neb-ci"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    NEB_IDPP = SimpleKeyword(
-        "neb-idpp"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    NEB_MMFTS = SimpleKeyword(
-        "neb-mmfts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    NEB_TS = SimpleKeyword(
-        "neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    FAST_NEB_TS = SimpleKeyword(
-        "fast-neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    LOOSE_NEB_TS = SimpleKeyword(
-        "loose-neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    TIGHT_NEB_TS = SimpleKeyword(
-        "tight-neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB = SimpleKeyword(
-        "zoom-neb"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB_CI = SimpleKeyword(
-        "zoom-neb-ci"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    ZOOM_NEB_TS = SimpleKeyword(
-        "zoom-neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    FLAT_NEB_TS = SimpleKeyword(
-        "flat-neb-ts"
-    )  # NEB for finding minimal energy pathways (and transition states)
-    IRC = SimpleKeyword("irc")  # internal reaction coordinate
-    SCANTS = SimpleKeyword("scants")  # scan for transition state
-    GOAT = SimpleKeyword("goat")  # GOAT Methods
-    GOAT_COARSE = SimpleKeyword("goat-coarse")  # GOAT Methods
-    GOAT_DIVERSITY = SimpleKeyword("goat-diversity")  # GOAT Methods
-    GOAT_ENTROPY = SimpleKeyword("goat-entropy")  # GOAT Methods
-    GOAT_EXPLORE = SimpleKeyword("goat-explore")  # GOAT Methods
-    GOAT_REACT = SimpleKeyword("goat-react")  # GOAT Methods
-    GOAT_TS = SimpleKeyword("goat-ts")  # GOAT Methods
-    NORMALDOCK = SimpleKeyword("normaldock")  # Docker Methods
-    COMPLETEDOCK = SimpleKeyword("completedock")  # Docker Methods
-    DOCK_GFN_FF = SimpleKeyword("dock(gfn-ff)")  # Docker Methods
-    DOCK_GFN0_XTB = SimpleKeyword("dock(gfn0-xtb)")  # Docker Methods
-    DOCK_GFN1_XTB = SimpleKeyword("dock(gfn1-xtb)")  # Docker Methods
-    DOCK_GFN2_XTB = SimpleKeyword("dock(gfn2-xtb)")  # Docker Methods
-    DOCK_GFNFF = SimpleKeyword("dock(gfnff)")  # Docker Methods
-    DOCK_XTB = SimpleKeyword("dock(xtb)")  # Docker Methods
-    DOCK_XTB0 = SimpleKeyword("dock(xtb0)")  # Docker Methods
-    DOCK_XTB1 = SimpleKeyword("dock(xtb1)")  # Docker Methods
-    DOCKER = SimpleKeyword("docker")  # Docker Methods
-    DOCKER_GFN_FF = SimpleKeyword("docker(gfn-ff)")  # Docker Methods
-    DOCKER_GFN0_XTB = SimpleKeyword("docker(gfn0-xtb)")  # Docker Methods
-    DOCKER_GFN1_XTB = SimpleKeyword("docker(gfn1-xtb)")  # Docker Methods
-    DOCKER_GFN2_XTB = SimpleKeyword("docker(gfn2-xtb)")  # Docker Methods
-    DOCKER_GFNFF = SimpleKeyword("docker(gfnff)")  # Docker Methods
-    DOCKER_XTB = SimpleKeyword("docker(xtb)")  # Docker Methods
-    DOCKER_XTB0 = SimpleKeyword("docker(xtb0)")  # Docker Methods
-    DOCKER_XTB1 = SimpleKeyword("docker(xtb1)")  # Docker Methods
-    QUICKDOCK = SimpleKeyword("quickdock")  # Docker Methods
-    SCREENDOCK = SimpleKeyword("screendock")  # Docker Methods
-    SOLVATOR = SimpleKeyword("solvator")  # Use the solvator for explicit solvation
-    ENMGRAD = SimpleKeyword("enmgrad")  # Energy normal mode gradient
-    CALCESTHESS = SimpleKeyword("calcesthess")  # Calculate an approximate hessian
-    MT = SimpleKeyword("mt")  # mode trajectory
-    NMSCAN = SimpleKeyword("nmscan")  # normal mode scan
-    PRINTTHERMOCHEM = SimpleKeyword("printthermochem")  # Only do thermostatistical corrections
-    PROPERTIESONLY = SimpleKeyword("propertiesonly")  # Only calc properties
-    NUMNAC = SimpleKeyword("numnac")  # Numerical non-adiabatic coupling
+    Attributes
+    ----------
+    SP : SimpleKeyword
+        perform a single point energy calculation (default)
+    ENGRAD : SimpleKeyword
+        Energy and gradient
+    OPT : SimpleKeyword
+        Perform geometry optimization
+    FREQ : SimpleKeyword
+        analytical frequency calculation
+    NUMFREQ : SimpleKeyword
+        numerical frequency calculation
+    MD : SimpleKeyword
+        molecular dynamics
+    EDA : SimpleKeyword
+        Perform an eda analysis
+    AUTOFRAG : SimpleKeyword
+        Automatic detection of fragments
+    CIM : SimpleKeyword
+        Calculate energy with clusters in molecule approach
+    CRUDEOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    LOOSEOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    NORMALOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    SLOPPYOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    TIGHTOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    VERYTIGHTOPT : SimpleKeyword
+        Geometry optimization with thresholds
+    OPTH : SimpleKeyword
+        Optimize only hydrogen atoms
+    COPT : SimpleKeyword
+        Perform geometry optimization (cartesian coordinates)
+    L_OPT : SimpleKeyword
+        Perform geometry optimization with lopt
+    L_OPTH : SimpleKeyword
+        Optimize only hydrogen atoms
+    EXTOPT : SimpleKeyword
+        Use only the geometry optimizer from orca with external energy/gradient
+    OPTTS : SimpleKeyword
+        optimize transition state
+    OPTTS_GMF : SimpleKeyword
+        optimize transition state
+    QMMMOPT : SimpleKeyword
+        Optimize the geometry with qmmm
+    QMMMOPT_PDYNAMO : SimpleKeyword
+        Optimize the geometry with qmmm
+    RIGIDBODYOPT : SimpleKeyword
+        Optimize fragments as rigid bodies
+    CI_OPT : SimpleKeyword
+        conical-intersection optimization
+    MECP_OPT : SimpleKeyword
+        MECP optimization
+    NEB : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    NEB_CI : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    NEB_IDPP : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    NEB_MMFTS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    FAST_NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    LOOSE_NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    TIGHT_NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    ZOOM_NEB : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    ZOOM_NEB_CI : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    ZOOM_NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    FLAT_NEB_TS : SimpleKeyword
+        NEB for finding minimal energy pathways (and transition states)
+    IRC : SimpleKeyword
+        internal reaction coordinate
+    SCANTS : SimpleKeyword
+        scan for transition state
+    GOAT : SimpleKeyword
+        GOAT Methods
+    GOAT_COARSE : SimpleKeyword
+        GOAT Methods
+    GOAT_DIVERSITY : SimpleKeyword
+        GOAT Methods
+    GOAT_ENTROPY : SimpleKeyword
+        GOAT Methods
+    GOAT_EXPLORE : SimpleKeyword
+        GOAT Methods
+    GOAT_REACT : SimpleKeyword
+        GOAT Methods
+    GOAT_TS : SimpleKeyword
+        GOAT Methods
+    NORMALDOCK : SimpleKeyword
+        Docker Methods
+    COMPLETEDOCK : SimpleKeyword
+        Docker Methods
+    DOCK_GFN_FF : SimpleKeyword
+        Docker Methods
+    DOCK_GFN0_XTB : SimpleKeyword
+        Docker Methods
+    DOCK_GFN1_XTB : SimpleKeyword
+        Docker Methods
+    DOCK_GFN2_XTB : SimpleKeyword
+        Docker Methods
+    DOCK_GFNFF : SimpleKeyword
+        Docker Methods
+    DOCK_XTB : SimpleKeyword
+        Docker Methods
+    DOCK_XTB0 : SimpleKeyword
+        Docker Methods
+    DOCK_XTB1 : SimpleKeyword
+        Docker Methods
+    DOCKER : SimpleKeyword
+        Docker Methods
+    DOCKER_GFN_FF : SimpleKeyword
+        Docker Methods
+    DOCKER_GFN0_XTB : SimpleKeyword
+        Docker Methods
+    DOCKER_GFN1_XTB : SimpleKeyword
+        Docker Methods
+    DOCKER_GFN2_XTB : SimpleKeyword
+        Docker Methods
+    DOCKER_GFNFF : SimpleKeyword
+        Docker Methods
+    DOCKER_XTB : SimpleKeyword
+        Docker Methods
+    DOCKER_XTB0 : SimpleKeyword
+        Docker Methods
+    DOCKER_XTB1 : SimpleKeyword
+        Docker Methods
+    QUICKDOCK : SimpleKeyword
+        Docker Methods
+    SCREENDOCK : SimpleKeyword
+        Docker Methods
+    SOLVATOR : SimpleKeyword
+        Use the solvator for explicit solvation
+    ENMGRAD : SimpleKeyword
+        Energy normal mode gradient
+    CALCESTHESS : SimpleKeyword
+        Calculate an approximate hessian
+    MT : SimpleKeyword
+        mode trajectory
+    NMSCAN : SimpleKeyword
+        normal mode scan
+    PRINTTHERMOCHEM : SimpleKeyword
+        Only do thermostatistical corrections
+    PROPERTIESONLY : SimpleKeyword
+        Only calc properties
+    NUMNAC : SimpleKeyword
+        Numerical non-adiabatic coupling
+    """
+
+    SP = SimpleKeyword("sp")
+    ENGRAD = SimpleKeyword("engrad")
+    OPT = SimpleKeyword("opt")
+    FREQ = SimpleKeyword("freq")
+    NUMFREQ = SimpleKeyword("numfreq")
+    MD = SimpleKeyword("md")
+    EDA = SimpleKeyword("eda")
+    AUTOFRAG = SimpleKeyword("autofrag")
+    CIM = SimpleKeyword("cim")
+    CRUDEOPT = SimpleKeyword("crudeopt")
+    LOOSEOPT = SimpleKeyword("looseopt")
+    NORMALOPT = SimpleKeyword("normalopt")
+    SLOPPYOPT = SimpleKeyword("sloppyopt")
+    TIGHTOPT = SimpleKeyword("tightopt")
+    VERYTIGHTOPT = SimpleKeyword("verytightopt")
+    OPTH = SimpleKeyword("opth")
+    COPT = SimpleKeyword("copt")
+    L_OPT = SimpleKeyword("l-opt")
+    L_OPTH = SimpleKeyword("l-opth")
+    EXTOPT = SimpleKeyword("extopt")
+    OPTTS = SimpleKeyword("optts")
+    OPTTS_GMF = SimpleKeyword("optts(gmf)")
+    QMMMOPT = SimpleKeyword("qmmmopt")
+    QMMMOPT_PDYNAMO = SimpleKeyword("qmmmopt/pdynamo")
+    RIGIDBODYOPT = SimpleKeyword("rigidbodyopt")
+    CI_OPT = SimpleKeyword("ci-opt")
+    MECP_OPT = SimpleKeyword("mecp-opt")
+    NEB = SimpleKeyword("neb")
+    NEB_CI = SimpleKeyword("neb-ci")
+    NEB_IDPP = SimpleKeyword("neb-idpp")
+    NEB_MMFTS = SimpleKeyword("neb-mmfts")
+    NEB_TS = SimpleKeyword("neb-ts")
+    FAST_NEB_TS = SimpleKeyword("fast-neb-ts")
+    LOOSE_NEB_TS = SimpleKeyword("loose-neb-ts")
+    TIGHT_NEB_TS = SimpleKeyword("tight-neb-ts")
+    ZOOM_NEB = SimpleKeyword("zoom-neb")
+    ZOOM_NEB_CI = SimpleKeyword("zoom-neb-ci")
+    ZOOM_NEB_TS = SimpleKeyword("zoom-neb-ts")
+    FLAT_NEB_TS = SimpleKeyword("flat-neb-ts")
+    IRC = SimpleKeyword("irc")
+    SCANTS = SimpleKeyword("scants")
+    GOAT = SimpleKeyword("goat")
+    GOAT_COARSE = SimpleKeyword("goat-coarse")
+    GOAT_DIVERSITY = SimpleKeyword("goat-diversity")
+    GOAT_ENTROPY = SimpleKeyword("goat-entropy")
+    GOAT_EXPLORE = SimpleKeyword("goat-explore")
+    GOAT_REACT = SimpleKeyword("goat-react")
+    GOAT_TS = SimpleKeyword("goat-ts")
+    NORMALDOCK = SimpleKeyword("normaldock")
+    COMPLETEDOCK = SimpleKeyword("completedock")
+    DOCK_GFN_FF = SimpleKeyword("dock(gfn-ff)")
+    DOCK_GFN0_XTB = SimpleKeyword("dock(gfn0-xtb)")
+    DOCK_GFN1_XTB = SimpleKeyword("dock(gfn1-xtb)")
+    DOCK_GFN2_XTB = SimpleKeyword("dock(gfn2-xtb)")
+    DOCK_GFNFF = SimpleKeyword("dock(gfnff)")
+    DOCK_XTB = SimpleKeyword("dock(xtb)")
+    DOCK_XTB0 = SimpleKeyword("dock(xtb0)")
+    DOCK_XTB1 = SimpleKeyword("dock(xtb1)")
+    DOCKER = SimpleKeyword("docker")
+    DOCKER_GFN_FF = SimpleKeyword("docker(gfn-ff)")
+    DOCKER_GFN0_XTB = SimpleKeyword("docker(gfn0-xtb)")
+    DOCKER_GFN1_XTB = SimpleKeyword("docker(gfn1-xtb)")
+    DOCKER_GFN2_XTB = SimpleKeyword("docker(gfn2-xtb)")
+    DOCKER_GFNFF = SimpleKeyword("docker(gfnff)")
+    DOCKER_XTB = SimpleKeyword("docker(xtb)")
+    DOCKER_XTB0 = SimpleKeyword("docker(xtb0)")
+    DOCKER_XTB1 = SimpleKeyword("docker(xtb1)")
+    QUICKDOCK = SimpleKeyword("quickdock")
+    SCREENDOCK = SimpleKeyword("screendock")
+    SOLVATOR = SimpleKeyword("solvator")
+    ENMGRAD = SimpleKeyword("enmgrad")
+    CALCESTHESS = SimpleKeyword("calcesthess")
+    MT = SimpleKeyword("mt")
+    NMSCAN = SimpleKeyword("nmscan")
+    PRINTTHERMOCHEM = SimpleKeyword("printthermochem")
+    PROPERTIESONLY = SimpleKeyword("propertiesonly")
+    NUMNAC = SimpleKeyword("numnac")

--- a/src/opi/input/simple_keywords/wft.py
+++ b/src/opi/input/simple_keywords/wft.py
@@ -7,45 +7,129 @@ __all__ = ("Wft",)
 
 
 class Wft(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Wft"""
+    """Enum to store all simple keywords of type Wft.
 
-    HF = SimpleKeyword("hf")  # Hartee-Fock
-    HF_3C = SimpleKeyword("hf-3c")  # 3c methods, do not require dispersion correction or basis set
-    MP2 = SimpleKeyword("mp2")  # WFT Methods
-    RIMP2 = SimpleKeyword("rimp2")  # WFT Methods
-    OO_RI_MP2 = SimpleKeyword("oo-ri-mp2")  # WFT Methods
-    SCS_MP2 = SimpleKeyword("scs-mp2")  # WFT Methods
-    SOS_MP2 = SimpleKeyword("sos-mp2")  # WFT Methods
-    DLPNO_MP2 = SimpleKeyword("dlpno-mp2")  # WFT Methods
-    DLPNO_SCS_MP2 = SimpleKeyword("dlpno-scs-mp2")  # WFT Methods
-    DLPNO_SOS_MP2 = SimpleKeyword("dlpno-sos-mp2")  # WFT Methods
-    DLPNO_MP2_F12 = SimpleKeyword("dlpno-mp2-f12")  # WFT Methods
-    DLPNO_MP2_F12D = SimpleKeyword("dlpno-mp2-f12d")  # WFT Methods
-    MP3 = SimpleKeyword("mp3")  # WFT Methods
-    SCS_MP3 = SimpleKeyword("scs-mp3")  # WFT Methods
-    CCSD = SimpleKeyword("ccsd")  # WFT Methods
-    CCSD_F12 = SimpleKeyword("ccsd-f12")  # WFT Methods
-    DLPNO_CCSD = SimpleKeyword("dlpno-ccsd")  # WFT Methods
-    DLPNO_CCSD_F12 = SimpleKeyword("dlpno-ccsd-f12")  # WFT Methods
-    DLPNO_CCSD_F12D = SimpleKeyword("dlpno-ccsd-f12d")  # WFT Methods
-    CCSD_T = SimpleKeyword("ccsd(t)")  # WFT Methods
-    CCSD_T_F12 = SimpleKeyword("ccsd(t)-f12")  # WFT Methods
-    DLPNO_CCSD_T = SimpleKeyword("dlpno-ccsd(t)")  # WFT Methods
-    DLPNO_CCSD_T1 = SimpleKeyword("dlpno-ccsd(t1)")  # WFT Methods
-    DLPNO_CCSD_T_F12 = SimpleKeyword("dlpno-ccsd(t)-f12")  # WFT Methods
-    DLPNO_CCSD_T_F12D = SimpleKeyword("dlpno-ccsd(t)-f12d")  # WFT Methods
-    DLPNO_CCSD_T1_F12 = SimpleKeyword("dlpno-ccsd(t1)-f12")  # WFT Methods
-    DLPNO_CCSD_T1_F12D = SimpleKeyword("dlpno-ccsd(t1)-f12d")  # WFT Methods
-    CISD = SimpleKeyword("cisd")  # WFT Methods
-    CISD_T = SimpleKeyword("cisd(t)")  # WFT Methods
-    CC2 = SimpleKeyword("cc2")  # WFT Methods
-    ADC2 = SimpleKeyword("adc2")  # WFT Methods
-    EOM_CCSD = SimpleKeyword("eom-ccsd")  # WFT Methods
-    DLPNO_CISD = SimpleKeyword("dlpno-cisd")  # WFT Methods
-    STEOM_CCSD = SimpleKeyword("steom-ccsd")  # WFT Methods
-    DLPNO_STEOM_CCSD = SimpleKeyword("dlpno-steom-ccsd")  # WFT Methods
-    CASPT2 = SimpleKeyword("caspt2")  # WFT Methods
-    CASPT2K = SimpleKeyword("caspt2k")  # WFT Methods
-    NEVPT2 = SimpleKeyword("nevpt2")  # WFT Methods
-    SC_NEVPT2 = SimpleKeyword("sc-nevpt2")  # WFT Methods
-    DLPNO_NEVPT2 = SimpleKeyword("dlpno-nevpt2")  # WFT Methods
+    Attributes
+    ----------
+    HF : SimpleKeyword
+        Hartee-Fock
+    HF_3C : SimpleKeyword
+        3c methods, do not require dispersion correction or basis set
+    MP2 : SimpleKeyword
+        WFT Methods
+    RIMP2 : SimpleKeyword
+        WFT Methods
+    OO_RI_MP2 : SimpleKeyword
+        WFT Methods
+    SCS_MP2 : SimpleKeyword
+        WFT Methods
+    SOS_MP2 : SimpleKeyword
+        WFT Methods
+    DLPNO_MP2 : SimpleKeyword
+        WFT Methods
+    DLPNO_SCS_MP2 : SimpleKeyword
+        WFT Methods
+    DLPNO_SOS_MP2 : SimpleKeyword
+        WFT Methods
+    DLPNO_MP2_F12 : SimpleKeyword
+        WFT Methods
+    DLPNO_MP2_F12D : SimpleKeyword
+        WFT Methods
+    MP3 : SimpleKeyword
+        WFT Methods
+    SCS_MP3 : SimpleKeyword
+        WFT Methods
+    CCSD : SimpleKeyword
+        WFT Methods
+    CCSD_F12 : SimpleKeyword
+        WFT Methods
+    DLPNO_CCSD : SimpleKeyword
+        WFT Methods
+    DLPNO_CCSD_F12 : SimpleKeyword
+        WFT Methods
+    DLPNO_CCSD_F12D : SimpleKeyword
+        WFT Methods
+    CCSD_T : SimpleKeyword
+        WFT Methods
+    CCSD_T_F12 : SimpleKeyword
+        WFT Methods
+    DLPNO_CCSD_T : SimpleKeyword
+        WFT Methods
+    DLPNO_CCSD_T1 : SimpleKeyword
+        WFT Methods
+    DLPNO_CCSD_T_F12 : SimpleKeyword
+        WFT Methods
+    DLPNO_CCSD_T_F12D : SimpleKeyword
+        WFT Methods
+    DLPNO_CCSD_T1_F12 : SimpleKeyword
+        WFT Methods
+    DLPNO_CCSD_T1_F12D : SimpleKeyword
+        WFT Methods
+    CISD : SimpleKeyword
+        WFT Methods
+    CISD_T : SimpleKeyword
+        WFT Methods
+    CC2 : SimpleKeyword
+        WFT Methods
+    ADC2 : SimpleKeyword
+        WFT Methods
+    EOM_CCSD : SimpleKeyword
+        WFT Methods
+    DLPNO_CISD : SimpleKeyword
+        WFT Methods
+    STEOM_CCSD : SimpleKeyword
+        WFT Methods
+    DLPNO_STEOM_CCSD : SimpleKeyword
+        WFT Methods
+    CASPT2 : SimpleKeyword
+        WFT Methods
+    CASPT2K : SimpleKeyword
+        WFT Methods
+    NEVPT2 : SimpleKeyword
+        WFT Methods
+    SC_NEVPT2 : SimpleKeyword
+        WFT Methods
+    DLPNO_NEVPT2 : SimpleKeyword
+        WFT Methods
+    """
+
+    HF = SimpleKeyword("hf")
+    HF_3C = SimpleKeyword("hf-3c")
+    MP2 = SimpleKeyword("mp2")
+    RIMP2 = SimpleKeyword("rimp2")
+    OO_RI_MP2 = SimpleKeyword("oo-ri-mp2")
+    SCS_MP2 = SimpleKeyword("scs-mp2")
+    SOS_MP2 = SimpleKeyword("sos-mp2")
+    DLPNO_MP2 = SimpleKeyword("dlpno-mp2")
+    DLPNO_SCS_MP2 = SimpleKeyword("dlpno-scs-mp2")
+    DLPNO_SOS_MP2 = SimpleKeyword("dlpno-sos-mp2")
+    DLPNO_MP2_F12 = SimpleKeyword("dlpno-mp2-f12")
+    DLPNO_MP2_F12D = SimpleKeyword("dlpno-mp2-f12d")
+    MP3 = SimpleKeyword("mp3")
+    SCS_MP3 = SimpleKeyword("scs-mp3")
+    CCSD = SimpleKeyword("ccsd")
+    CCSD_F12 = SimpleKeyword("ccsd-f12")
+    DLPNO_CCSD = SimpleKeyword("dlpno-ccsd")
+    DLPNO_CCSD_F12 = SimpleKeyword("dlpno-ccsd-f12")
+    DLPNO_CCSD_F12D = SimpleKeyword("dlpno-ccsd-f12d")
+    CCSD_T = SimpleKeyword("ccsd(t)")
+    CCSD_T_F12 = SimpleKeyword("ccsd(t)-f12")
+    DLPNO_CCSD_T = SimpleKeyword("dlpno-ccsd(t)")
+    DLPNO_CCSD_T1 = SimpleKeyword("dlpno-ccsd(t1)")
+    DLPNO_CCSD_T_F12 = SimpleKeyword("dlpno-ccsd(t)-f12")
+    DLPNO_CCSD_T_F12D = SimpleKeyword("dlpno-ccsd(t)-f12d")
+    DLPNO_CCSD_T1_F12 = SimpleKeyword("dlpno-ccsd(t1)-f12")
+    DLPNO_CCSD_T1_F12D = SimpleKeyword("dlpno-ccsd(t1)-f12d")
+    CISD = SimpleKeyword("cisd")
+    CISD_T = SimpleKeyword("cisd(t)")
+    CC2 = SimpleKeyword("cc2")
+    ADC2 = SimpleKeyword("adc2")
+    EOM_CCSD = SimpleKeyword("eom-ccsd")
+    DLPNO_CISD = SimpleKeyword("dlpno-cisd")
+    STEOM_CCSD = SimpleKeyword("steom-ccsd")
+    DLPNO_STEOM_CCSD = SimpleKeyword("dlpno-steom-ccsd")
+    CASPT2 = SimpleKeyword("caspt2")
+    CASPT2K = SimpleKeyword("caspt2k")
+    NEVPT2 = SimpleKeyword("nevpt2")
+    SC_NEVPT2 = SimpleKeyword("sc-nevpt2")
+    DLPNO_NEVPT2 = SimpleKeyword("dlpno-nevpt2")

--- a/src/opi/input/simple_keywords/wft.py
+++ b/src/opi/input/simple_keywords/wft.py
@@ -7,129 +7,85 @@ __all__ = ("Wft",)
 
 
 class Wft(SimpleKeywordBox):
-    """Enum to store all simple keywords of type Wft.
-
-    Attributes
-    ----------
-    HF : SimpleKeyword
-        Hartee-Fock
-    HF_3C : SimpleKeyword
-        3c methods, do not require dispersion correction or basis set
-    MP2 : SimpleKeyword
-        WFT Methods
-    RIMP2 : SimpleKeyword
-        WFT Methods
-    OO_RI_MP2 : SimpleKeyword
-        WFT Methods
-    SCS_MP2 : SimpleKeyword
-        WFT Methods
-    SOS_MP2 : SimpleKeyword
-        WFT Methods
-    DLPNO_MP2 : SimpleKeyword
-        WFT Methods
-    DLPNO_SCS_MP2 : SimpleKeyword
-        WFT Methods
-    DLPNO_SOS_MP2 : SimpleKeyword
-        WFT Methods
-    DLPNO_MP2_F12 : SimpleKeyword
-        WFT Methods
-    DLPNO_MP2_F12D : SimpleKeyword
-        WFT Methods
-    MP3 : SimpleKeyword
-        WFT Methods
-    SCS_MP3 : SimpleKeyword
-        WFT Methods
-    CCSD : SimpleKeyword
-        WFT Methods
-    CCSD_F12 : SimpleKeyword
-        WFT Methods
-    DLPNO_CCSD : SimpleKeyword
-        WFT Methods
-    DLPNO_CCSD_F12 : SimpleKeyword
-        WFT Methods
-    DLPNO_CCSD_F12D : SimpleKeyword
-        WFT Methods
-    CCSD_T : SimpleKeyword
-        WFT Methods
-    CCSD_T_F12 : SimpleKeyword
-        WFT Methods
-    DLPNO_CCSD_T : SimpleKeyword
-        WFT Methods
-    DLPNO_CCSD_T1 : SimpleKeyword
-        WFT Methods
-    DLPNO_CCSD_T_F12 : SimpleKeyword
-        WFT Methods
-    DLPNO_CCSD_T_F12D : SimpleKeyword
-        WFT Methods
-    DLPNO_CCSD_T1_F12 : SimpleKeyword
-        WFT Methods
-    DLPNO_CCSD_T1_F12D : SimpleKeyword
-        WFT Methods
-    CISD : SimpleKeyword
-        WFT Methods
-    CISD_T : SimpleKeyword
-        WFT Methods
-    CC2 : SimpleKeyword
-        WFT Methods
-    ADC2 : SimpleKeyword
-        WFT Methods
-    EOM_CCSD : SimpleKeyword
-        WFT Methods
-    DLPNO_CISD : SimpleKeyword
-        WFT Methods
-    STEOM_CCSD : SimpleKeyword
-        WFT Methods
-    DLPNO_STEOM_CCSD : SimpleKeyword
-        WFT Methods
-    CASPT2 : SimpleKeyword
-        WFT Methods
-    CASPT2K : SimpleKeyword
-        WFT Methods
-    NEVPT2 : SimpleKeyword
-        WFT Methods
-    SC_NEVPT2 : SimpleKeyword
-        WFT Methods
-    DLPNO_NEVPT2 : SimpleKeyword
-        WFT Methods
-    """
+    """Enum to store all simple keywords of type Wft."""
 
     HF = SimpleKeyword("hf")
+    """SimpleKeyword: Hartee-Fock."""
     HF_3C = SimpleKeyword("hf-3c")
+    """SimpleKeyword: 3c methods, do not require dispersion correction or basis set."""
     MP2 = SimpleKeyword("mp2")
+    """SimpleKeyword: WFT Methods."""
     RIMP2 = SimpleKeyword("rimp2")
+    """SimpleKeyword: WFT Methods."""
     OO_RI_MP2 = SimpleKeyword("oo-ri-mp2")
+    """SimpleKeyword: WFT Methods."""
     SCS_MP2 = SimpleKeyword("scs-mp2")
+    """SimpleKeyword: WFT Methods."""
     SOS_MP2 = SimpleKeyword("sos-mp2")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_MP2 = SimpleKeyword("dlpno-mp2")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_SCS_MP2 = SimpleKeyword("dlpno-scs-mp2")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_SOS_MP2 = SimpleKeyword("dlpno-sos-mp2")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_MP2_F12 = SimpleKeyword("dlpno-mp2-f12")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_MP2_F12D = SimpleKeyword("dlpno-mp2-f12d")
+    """SimpleKeyword: WFT Methods."""
     MP3 = SimpleKeyword("mp3")
+    """SimpleKeyword: WFT Methods."""
     SCS_MP3 = SimpleKeyword("scs-mp3")
+    """SimpleKeyword: WFT Methods."""
     CCSD = SimpleKeyword("ccsd")
+    """SimpleKeyword: WFT Methods."""
     CCSD_F12 = SimpleKeyword("ccsd-f12")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_CCSD = SimpleKeyword("dlpno-ccsd")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_CCSD_F12 = SimpleKeyword("dlpno-ccsd-f12")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_CCSD_F12D = SimpleKeyword("dlpno-ccsd-f12d")
+    """SimpleKeyword: WFT Methods."""
     CCSD_T = SimpleKeyword("ccsd(t)")
+    """SimpleKeyword: WFT Methods."""
     CCSD_T_F12 = SimpleKeyword("ccsd(t)-f12")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_CCSD_T = SimpleKeyword("dlpno-ccsd(t)")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_CCSD_T1 = SimpleKeyword("dlpno-ccsd(t1)")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_CCSD_T_F12 = SimpleKeyword("dlpno-ccsd(t)-f12")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_CCSD_T_F12D = SimpleKeyword("dlpno-ccsd(t)-f12d")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_CCSD_T1_F12 = SimpleKeyword("dlpno-ccsd(t1)-f12")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_CCSD_T1_F12D = SimpleKeyword("dlpno-ccsd(t1)-f12d")
+    """SimpleKeyword: WFT Methods."""
     CISD = SimpleKeyword("cisd")
+    """SimpleKeyword: WFT Methods."""
     CISD_T = SimpleKeyword("cisd(t)")
+    """SimpleKeyword: WFT Methods."""
     CC2 = SimpleKeyword("cc2")
+    """SimpleKeyword: WFT Methods."""
     ADC2 = SimpleKeyword("adc2")
+    """SimpleKeyword: WFT Methods."""
     EOM_CCSD = SimpleKeyword("eom-ccsd")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_CISD = SimpleKeyword("dlpno-cisd")
+    """SimpleKeyword: WFT Methods."""
     STEOM_CCSD = SimpleKeyword("steom-ccsd")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_STEOM_CCSD = SimpleKeyword("dlpno-steom-ccsd")
+    """SimpleKeyword: WFT Methods."""
     CASPT2 = SimpleKeyword("caspt2")
+    """SimpleKeyword: WFT Methods."""
     CASPT2K = SimpleKeyword("caspt2k")
+    """SimpleKeyword: WFT Methods."""
     NEVPT2 = SimpleKeyword("nevpt2")
+    """SimpleKeyword: WFT Methods."""
     SC_NEVPT2 = SimpleKeyword("sc-nevpt2")
+    """SimpleKeyword: WFT Methods."""
     DLPNO_NEVPT2 = SimpleKeyword("dlpno-nevpt2")
+    """SimpleKeyword: WFT Methods."""


### PR DESCRIPTION
Initial conversion of comments to docstrings in simple keywords. Further refinement of docstrings will be an ongoing task.

**Attention:** This is a breaking change since redundant keywords were removed (mostly keywords in task.py which already have their own sub-category)