### PR TITLE
Docs: Makefile sourcing venv

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,10 +2,13 @@ SPHINXOPTS    ?=
 SOURCEDIR     = .
 BUILDDIR      = _build
 VENV_DIR      = .venv
+VENV_ACTIVATE = $(VENV_DIR)/bin/activate
 PYTHON        = $(VENV_DIR)/bin/python3
 SPHINXPROJ    = ORCA Python Interface tutorials
 SPHINXBUILD   = $(PYTHON) -m sphinx
 SPHINXAUTO    = $(PYTHON) -m sphinx_autobuild
+
+SHELL := /bin/bash
 
 clean_api:
 	rm -rf "$(SOURCEDIR)/contents/api"
@@ -21,20 +24,20 @@ distclean: clean clean_api
 $(VENV_DIR)/bin/uv:
 	@if [ ! -d "$(VENV_DIR)/bin/activate" ]; then \
 		python3 -m venv $(VENV_DIR); \
-		$(PYTHON) -m pip install --upgrade pip; \
+		source $(VENV_ACTIVATE) && $(PYTHON) -m pip install --upgrade pip; \
 	fi
 	@if [ ! -f "$(VENV_DIR)/bin/uv" ]; then \
-		$(PYTHON) -m pip install --upgrade uv; \
+		source $(VENV_ACTIVATE) && $(PYTHON) -m pip install --upgrade uv; \
 	fi
 
 sphinx: $(VENV_DIR)/bin/uv
-	$(PYTHON) -m uv sync --active --group docs --no-editable --locked --no-python-downloads
+	source $(VENV_ACTIVATE) && $(PYTHON) -m uv sync --active --group docs --no-editable --locked --no-python-downloads
 
 auto: sphinx
-	@$(SPHINXAUTO) --re-ignore $(BUILDDIR) $(SOURCEDIR) $(BUILDDIR)/html
+	source $(VENV_ACTIVATE) && $(SPHINXAUTO) --re-ignore $(BUILDDIR) $(SOURCEDIR) $(BUILDDIR)/html
 
 html: sphinx
-	$(SPHINXBUILD) . $(BUILDDIR)/html
+	source $(VENV_ACTIVATE) && $(SPHINXBUILD) . $(BUILDDIR)/html
 
 # > Phony targets
 .PHONY: auto clean clean_generated distclean html sphinx


### PR DESCRIPTION
Docs: Explicitly sourcing the venv in every target to avoid conflicts with potentially other active venvs.