### PR TITLE
Bugfix for single-atom calculation

### DIFF
--- a/src/opi/output/models/json/property/properties/mayer_population_analysis.py
+++ b/src/opi/output/models/json/property/properties/mayer_population_analysis.py
@@ -15,7 +15,7 @@ class MayerPopulationAnalysis(PopulationAnalysis):
     ----------
     bondthresh: StrictPositiveFiniteFloat | None, default = None
         Threshold for the bound order to be printed
-    nbondordersprint: StrictPositiveInt | None, default = None
+    nbondordersprint: StrictNonNegativeInt | None, default = None
         Number of bounds
     bondorders: list[list[StrictFiniteFloat]] | None, default = None
         Bound order of each Bound
@@ -36,7 +36,7 @@ class MayerPopulationAnalysis(PopulationAnalysis):
     """
 
     bondthresh: StrictPositiveFloat | None = None
-    nbondordersprint: StrictPositiveInt | None = None
+    nbondordersprint: StrictNonNegativeInt | None = None
     bondorders: list[list[StrictFiniteFloat]] | None = None
     components: (
         list[


### PR DESCRIPTION
Fix for output parser breaking for single-atom calculations due to the a Mayer bond order of zero.