### PR TITLE
Fix gbw json creation for multi-gbw runs

### DIFF
--- a/examples/exmp039_neb/job.py
+++ b/examples/exmp039_neb/job.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     calc.write_input()
     calc.run()
 
-    output = calc.get_output(create_gbw_json=True)
+    output = calc.get_output()
     if not output.terminated_normally():
         print(f"ORCA calculation failed, see output file: {output.get_outfile()}")
         sys.exit(1)

--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -226,8 +226,12 @@ class Output:
             If the Path leads to no file
         """
 
+        # > If the gbw file does not exist we try to create it
         if not json_file.is_file():
-            raise FileNotFoundError(f"JSON file does not exist: {json_file}")
+            try:
+                self.create_gbw_json()
+            except:
+                raise FileNotFoundError(f"JSON file does not exist: {json_file}")
 
         with json_file.open() as f_json:
             json_data: dict[str, Any] = json.load(f_json)


### PR DESCRIPTION
Adds fallback to try to create missing gbw json files with orca_2json. For multi-gbw runs the json files have to be created by orca_2json so either one has to specifically request orca_2json in the creation of `Output` or this fallback has to create them. 