### PR TITLE
ORCA binary version check

### DIFF
--- a/src/opi/__init__.py
+++ b/src/opi/__init__.py
@@ -11,4 +11,4 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"  # Fallback for development mode
 
 # // ORCA VERSION
-ORCA_MINIMAL_VERSION = OrcaVersion.from_str("6.1")
+ORCA_MINIMAL_VERSION = OrcaVersion.from_str("6.1.0-f.0")

--- a/src/opi/core.py
+++ b/src/opi/core.py
@@ -43,7 +43,11 @@ class Calculator:
     """
 
     def __init__(
-        self, basename: str, working_dir: Path | str | PathLike[str] | None = None
+        self,
+        basename: str,
+        working_dir: Path | str | PathLike[str] | None = None,
+        *,
+        version_check: bool = True,
     ) -> None:
         """
         Parameters
@@ -52,6 +56,8 @@ class Calculator:
             Basename of the calculation. Each file created by ORCA starts with this prefix.
         working_dir : Path | str | None, default=None
             Optional working direction. Is passed on to `Runner` and `Output` classes.
+        version_check : bool, default: True
+            Check ORCA's binary version upon initialization.
         """
 
         # -----------------------------
@@ -84,6 +90,13 @@ class Calculator:
         # > ORCA INPUT
         # -----------------------------
         self._input: Input = Input()
+
+        # ----------------------------
+        # > BINARY VERSION CHECK
+        # ----------------------------
+        if version_check:
+            # > Raises RuntimeError if version is not compatible or cannot be determined.
+            self.check_version()
 
     # &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
     # PROPERTIES
@@ -328,3 +341,19 @@ class Calculator:
         return Output(
             basename=self.basename, working_dir=self.working_dir, create_gbw_json=create_gbw_json
         )
+
+    def check_version(self) -> None:
+        """
+        Check if the ORCA version of the binary is compatible with the current OPI version.
+        Soft-wrapper around Runner.check_version().
+
+        Raises
+        ------
+        RuntimeError: If version could not be determined or is not compatible.
+        """
+        runner = self._create_runner()
+        # > Can raise RuntimeError
+        try:
+            runner.check_version(ignore_errors=False)
+        except RuntimeError:
+            raise

--- a/src/opi/core.py
+++ b/src/opi/core.py
@@ -58,6 +58,7 @@ class Calculator:
             Optional working direction. Is passed on to `Runner` and `Output` classes.
         version_check : bool, default: True
             Check ORCA's binary version upon initialization.
+            Important: May create significant computational overhead if many `Calculators` are initialized concurrently.
         """
 
         # -----------------------------

--- a/src/opi/execution/core.py
+++ b/src/opi/execution/core.py
@@ -379,7 +379,7 @@ class Runner:
 
         try:
             # > May raise subprocess.TimeoutExpired
-            orca_proc = self.run(OrcaBinary.ORCA, capture=True, timeout=5)
+            orca_proc = self.run(OrcaBinary.ORCA, ["--version"], capture=True, timeout=5)
 
             # > Pleasing type checker
             assert isinstance(orca_proc, CompletedProcess)
@@ -413,13 +413,20 @@ class Runner:
 
         orca_vers = self.get_version()
 
+        # > Path as string to ORCA binary
+        try:
+            orca_bin_str = f"\nORCA binary: {self.get_orca_binary(OrcaBinary.ORCA)}"
+        except FileNotFoundError:
+            orca_bin_str = ""
+
         if orca_vers is None:
             if ignore_errors:
                 return None
             else:
                 raise RuntimeError(
-                    f"Could not determine version of ORCA binary. Make sure ORCA is installed and configured correctly."
-                    f" Minimally required ORCA version: {ORCA_MINIMAL_VERSION}"
+                    f"Could not determine version of ORCA binary."
+                    f" Make sure ORCA is installed and configured correctly."
+                    f" Minimally required ORCA version: {ORCA_MINIMAL_VERSION}{orca_bin_str}"
                 )
 
         elif not check_minimal_version(orca_vers):
@@ -427,7 +434,8 @@ class Runner:
                 return False
             else:
                 raise RuntimeError(
-                    f"ORCA version {orca_vers} is not supported. Make sure to install at least version: {ORCA_MINIMAL_VERSION}"
+                    f"ORCA version {orca_vers} is not supported. Make sure to install at least version:"
+                    f" {ORCA_MINIMAL_VERSION}{orca_bin_str}"
                 )
         else:
             return True

--- a/src/opi/execution/core.py
+++ b/src/opi/execution/core.py
@@ -401,7 +401,7 @@ class Runner:
         Returns
         -------
         bool :
-            True: Ff version is compatible.
+            True: If version is compatible.
             False: If version is not compatible.
         None :
             If version could not be determined.

--- a/src/opi/execution/core.py
+++ b/src/opi/execution/core.py
@@ -15,10 +15,13 @@ from contextlib import nullcontext
 from enum import StrEnum
 from io import TextIOWrapper
 from pathlib import Path
+from subprocess import CompletedProcess
 from typing import Any, Callable, Sequence, TypeVar, cast
 
+from opi import ORCA_MINIMAL_VERSION
 from opi.utils.config import get_config
-from opi.utils.misc import add_to_env, delete_empty_file
+from opi.utils.misc import add_to_env, check_minimal_version, delete_empty_file
+from opi.utils.orca_version import OrcaVersion
 
 
 class OrcaBinary(StrEnum):
@@ -189,6 +192,8 @@ class Runner:
         ------
         FileNotFound:
           Error if path to ORCA binary cannot be resolved.
+        subprocess.TimeoutExpired:
+            If `timeout>-1` and the process times out.
         """
 
         # ------------------------------------------------------------
@@ -359,6 +364,73 @@ class Runner:
             silent=silent,
             timeout=timeout,
         )
+
+    def get_version(self) -> OrcaVersion | None:
+        """
+        Get the ORCA version from the main ORCA binary.
+
+        Returns
+        -------
+        OrcaVersion:
+            Version of the ORCA.
+        None:
+            If the version could not be determined.
+        """
+
+        try:
+            # > May raise subprocess.TimeoutExpired
+            orca_proc = self.run(OrcaBinary.ORCA, capture=True, timeout=5)
+
+            # > Pleasing type checker
+            assert isinstance(orca_proc, CompletedProcess)
+            return OrcaVersion.from_output(orca_proc.stdout)
+
+        except (subprocess.TimeoutExpired, ValueError, AssertionError):
+            return None
+
+    def check_version(self, *, ignore_errors: bool = False) -> bool | None:
+        """
+        Check if the ORCA version of the binary is compatible with the current OPI version.
+
+        Parameters
+        ----------
+        ignore_errors : bool, default: False
+            False: Raises RuntimeError if version is not compatible or could not be determined.
+            True: Return True if version is compatible, else return False. Also if the version could not be determined.
+
+        Returns
+        -------
+        bool :
+            True: Ff version is compatible.
+            False: If version is not compatible.
+        None :
+            If version could not be determined.
+
+        Raises
+        ------
+        RuntimeError: If `ignore_errors` is False and version is not compatible or could not be determined.
+        """
+
+        orca_vers = self.get_version()
+
+        if orca_vers is None:
+            if ignore_errors:
+                return None
+            else:
+                raise RuntimeError(
+                    f"Could not determine version of ORCA binary. Make sure ORCA is installed and configured correctly."
+                    f" Minimally required ORCA version: {ORCA_MINIMAL_VERSION}"
+                )
+
+        elif not check_minimal_version(orca_vers):
+            if ignore_errors:
+                return False
+            else:
+                raise RuntimeError(
+                    f"ORCA version {orca_vers} is not supported. Make sure to install at least version: {ORCA_MINIMAL_VERSION}"
+                )
+        else:
+            return True
 
     @staticmethod
     def _determine_orca_paths(orca_path: Path, /) -> tuple[Path, Path]:

--- a/src/opi/utils/orca_version.py
+++ b/src/opi/utils/orca_version.py
@@ -11,11 +11,15 @@ class OrcaVersion(Version):  # type: ignore
     """
 
     RGX_VERSION = re.compile(
-        r"(?P<major>\d+)"  # major version
-        r"\.(?P<minor>\d+)"  # minor version
+        # major version
+        r"(?P<major>\d+)"  
+        # minor version
+        r"\.(?P<minor>\d+)"  
         r"("
-        r"\.(?P<micro>\d+)"  # micro version [optional]
-         r"(-(?P<bugfix>f\.\d+))?"  # bugfix version [optional]
+        # micro version [optional]
+        r"\.(?P<micro>\d+)"
+        # bugfix version [optional]
+        r"(-(?P<bugfix>f\.\d+))?"  
         r")?",
         re.VERBOSE | re.IGNORECASE,
     )

--- a/src/opi/utils/orca_version.py
+++ b/src/opi/utils/orca_version.py
@@ -15,7 +15,7 @@ class OrcaVersion(Version):  # type: ignore
         r"\.(?P<minor>\d+)"  # minor version
         r"("
         r"\.(?P<micro>\d+)"  # micro version [optional]
-        r"(-f\.(?P<bugfix>\d+))?"  # bugfix version [optional]
+         r"(-(?P<bugfix>f\.\d+))?"  # bugfix version [optional]
         r")?",
         re.VERBOSE | re.IGNORECASE,
     )
@@ -43,7 +43,7 @@ class OrcaVersion(Version):  # type: ignore
             minor = int(mmatch.group("minor"))
             # > Patch level has to be a number. Cannot be None.
             patch = int(g) if (g := mmatch.group("micro")) else 0
-            prerelease = int(g) if (g := mmatch.group("bugfix")) else None
+            prerelease = g.split(".") if (g := mmatch.group("bugfix")) else None
 
             return cls(
                 major=major,


### PR DESCRIPTION
Added automatic, optional (default is: on) ORCA binary version check, that stops OPI if the found ORCA version is not compatible with ORCA or if it fails.
Added routines:
* `Runner.get_version()`
* `Runner.check_version()`
* `Calculator.check_version()`

Addresses #107 

Fixed bug in `OrcaVersion`.
Corrected `ORCA_MINIMAL_VERSION`.