### PR TITLE
Fixed `opi.__version__`

### DIFF
--- a/src/opi/__init__.py
+++ b/src/opi/__init__.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+from warnings import warn
 
 from opi.utils.orca_version import OrcaVersion
 
@@ -6,8 +7,9 @@ __all__ = ["ORCA_MINIMAL_VERSION"]
 
 # // OPI VERSION
 try:
-    __version__ = importlib.metadata.version(__name__)
-except importlib.metadata.PackageNotFoundError:
+    __version__ = importlib.metadata.version("orca-pi")
+except importlib.metadata.PackageNotFoundError as err:
+    warn(str(err), RuntimeWarning)
     __version__ = "0.0.0"  # Fallback for development mode
 
 # // ORCA VERSION


### PR DESCRIPTION
Fixed `opi.__version__` which would always display the fallback version `0.0.0` because the metadata are stored for 'orca-pi'.