### PR TITLE
Fixed ORCA binary lookup on Windows

### DIFF
--- a/src/opi/execution/core.py
+++ b/src/opi/execution/core.py
@@ -609,7 +609,7 @@ class Runner:
             bin_name += ".exe"
 
         # > Full path to ORCA binary
-        orca_binary = self._orca_bin_folder / str(binary)
+        orca_binary = self._orca_bin_folder / bin_name
 
         if not orca_binary.is_file():
             raise FileNotFoundError(f"The ORCA binary does not exist: {orca_binary}")


### PR DESCRIPTION
Fixed lookup of ORCA binaries on Windows.
On Windows, all binaries end with '.exe'.