### PR TITLE
add force parameter to Calculator.write_input() and created Calculator.create_and_run()

### DIFF
--- a/src/opi/core.py
+++ b/src/opi/core.py
@@ -204,7 +204,9 @@ class Calculator:
 
         exists = self._inpfile.exists()
         if exists and not force:
-            raise RuntimeError(f"Input file {self._inpfile} already exists and cannot be overwritten.")
+            raise RuntimeError(
+                f"Input file {self._inpfile} already exists and cannot be overwritten."
+            )
         input_overwritten = exists and force
 
         # add JSON generation to output blocks


### PR DESCRIPTION
- to close #78 and #77
- Not sure if returning a boolean here would be necessary since the error is raised in the case that the file cannot be overwritten.
- created Calculator.create_and_run()