### PR TITLE
Docu: "--no-advice" would crash with older git versions.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,9 +75,11 @@ full_version = ""
 version_short = ""
 # > Using "main" as fallback
 release_branch = "main"
+# > Disabling git advices
+os.environ["GIT_ADVICE"] = "0"
 try:
     output = check_output(
-        ["git", "--no-advice", "--no-pager", "describe", "--always"],
+        ["git", "--no-pager", "describe", "--always"],
         timeout=5,
         cwd=origin,
         text=True,

--- a/src/opi/utils/orca_version.py
+++ b/src/opi/utils/orca_version.py
@@ -12,14 +12,14 @@ class OrcaVersion(Version):  # type: ignore
 
     RGX_VERSION = re.compile(
         # major version
-        r"(?P<major>\d+)"  
+        r"(?P<major>\d+)"
         # minor version
-        r"\.(?P<minor>\d+)"  
+        r"\.(?P<minor>\d+)"
         r"("
         # micro version [optional]
         r"\.(?P<micro>\d+)"
         # bugfix version [optional]
-        r"(-(?P<bugfix>f\.\d+))?"  
+        r"(-(?P<bugfix>f\.\d+))?"
         r")?",
         re.VERBOSE | re.IGNORECASE,
     )


### PR DESCRIPTION
Fixes bug introduced with PR https://github.com/faccts/opi/pull/115
Replaced `--no-advice` with env. variable: `$GIT_ADVICE=0`