### PR TITLE
Add warning about impossible multiplicities to Structure

### DIFF
--- a/src/opi/execution/core.py
+++ b/src/opi/execution/core.py
@@ -20,9 +20,8 @@ from typing import Any, Callable, Sequence, TypeVar, cast
 
 from opi import ORCA_MINIMAL_VERSION
 from opi.utils.config import get_config
-from opi.utils.misc import add_to_env, check_minimal_version, delete_empty_file
+from opi.utils.misc import add_to_env, check_minimal_version, delete_empty_file, is_windows
 from opi.utils.orca_version import OrcaVersion
-from opi.utils.misc import is_windows
 
 
 class OrcaBinary(StrEnum):

--- a/src/opi/input/structures/structure.py
+++ b/src/opi/input/structures/structure.py
@@ -170,6 +170,21 @@ class Structure:
         """Returns a boolean indicating if the multiplicity is even."""
         return self.multiplicity % 2 == 0
 
+    @property
+    def nelec_and_multiplicity_even(self) -> bool:
+        """Returns a boolean indicating if the number of electrons and the multiplicity are even."""
+        return self.nelec_is_even and self.multiplicity_is_even
+
+    @property
+    def nelec_and_multiplicity_odd(self) -> bool:
+        """Returns a boolean indicating if the number of electrons and the multiplicity are odd."""
+        return self.nelec_is_odd and self.multiplicity_is_odd
+
+    @property
+    def multiplicity_is_possible(self) -> bool:
+        """Returns a boolean indicating if the multiplicity can be realized with the number of electrons."""
+        return not (self.nelec_and_multiplicity_even or self.nelec_and_multiplicity_odd)
+
     def set_ls_multiplicity(self) -> None:
         """
         Sets `multiplicity` to the lowest possible multiplicity based on the number of electrons (`multiplicitiy`
@@ -211,16 +226,13 @@ class Structure:
                 String representation of Molecule
         """
         # > First we check whether the multiplicity is possible with the numbers of electrons and warn if not
-
-        # > nelec and multiplicity are even
-        if self.nelec_is_even and self.multiplicity_is_even:
+        if self.nelec_and_multiplicity_even:
             warn(
                 "Inconsistent input: an even number of electrons cannot have even multiplicity",
                 UserWarning,
             )
 
-        # > nelec and multiplicity are odd
-        if self.nelec_is_odd and self.multiplicity_is_odd:
+        if self.nelec_and_multiplicity_odd:
             warn(
                 "Inconsistent input: an odd number of electrons cannot have odd multiplicity",
                 UserWarning,


### PR DESCRIPTION
- Adds a warning if the multiplicity in the structure and the number of electrons are both even or both odd, which cannot be -> ORCA will fail with this input
- Adds a convenience function to Structure `set_ls_multiplicity()` which selects the lowest possible multiplicity. If you know that you either have singlets or doublets you can use this function for quick input generation. 