### PR TITLE
Update ML Notebook

### DIFF
--- a/docs/contents/notebooks/ml_properties.ipynb
+++ b/docs/contents/notebooks/ml_properties.ipynb
@@ -7,10 +7,10 @@
    "source": [
     "# Properties for ML models\n",
     "\n",
-    "This tutorial demonstrates how to use ORCA together with the ORCA python interface (OPI) to calculate electronic properties relevant for, e.g., training machine-learned interatomic potentials (MLIPs). As an example, we will use the reference level &omega;B97M-V/def2-TZVPD and the settings used for generating the [OMol25](https://arxiv.org/abs/2505.08762) dataset. As an exemplary molecule, we use 4-methylpyrazole.\n",
+    "This tutorial demonstrates how to use ORCA together with the ORCA Python interface (OPI) to calculate electronic properties relevant for, e.g., training machine-learned interatomic potentials (MLIPs). As an example, we will use the reference level &omega;B97M-V/def2-TZVPD and the settings used for generating the [OMol25](https://arxiv.org/abs/2505.08762) dataset. As an exemplary molecule, we use 4-methylpyrazole.\n",
     "\n",
     "In this notebook we will:\n",
-    "1.  Import the required python dependencies.\n",
+    "1.  Import the required Python dependencies.\n",
     "2.  Define a working directory.\n",
     "3.  Set up the input structure.\n",
     "4.  Define the calculation settings.\n",
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "61fac6de",
    "metadata": {},
    "outputs": [
@@ -156,7 +156,7 @@
     }
    ],
    "source": [
-    "# > define cartesian coordinates in angstrom as python string \n",
+    "# > Define cartesian coordinates in angstrom as Python string \n",
     "xyz_data = \"\"\"\\\n",
     "12\n",
     "\n",


### PR DESCRIPTION
The [Properties for ML models](https://www.faccts.de/docs/opi/nightly/docs/contents/notebooks/ml_properties.html) notebook was not updated after some breaking changes regarding the orbital handling were introduced. While the MOs were previously stored as `results_gbw.molecule.molecularorbitals.mos` in the output class, they now can be accessed directly with `get_mos()`.