### PR TITLE
Improved typing of the _orca_environment decorator

### DIFF
--- a/src/opi/execution/core.py
+++ b/src/opi/execution/core.py
@@ -37,7 +37,7 @@ def _orca_environment(
 
     Parameters
     ----------
-    runner : Callable[..., R]
+    runner : Callable[Concatenate[RunnerType, P], R]
         Function that is to be wrapped.
     """
 


### PR DESCRIPTION
Minor quality of life improvement to the `_orca_environment` decorator. Previously typing information was being erased by using the ellipsis. As this project has a minimum specified python version of 3.11 it can benefit from the `Concatenate` and `ParamSpec` typed introduced by [PEP 612](https://peps.python.org/pep-0612/) in python 3.10.

The previous ellipsis in the decorator removes the function arguments preventing the IDE and type checker from checking the arguments only allowing checking on the return type.

**With ellipsis**
<img width="927" height="419" alt="Screenshot from 2026-01-30 12-12-53" src="https://github.com/user-attachments/assets/7e5f7f22-5bd7-4c3f-a3c7-053a83da60e6" />
<img width="319" height="189" alt="Screenshot from 2026-01-30 12-35-54" src="https://github.com/user-attachments/assets/51252d18-b251-4892-976c-c1460ef8ac46" />

**With `Concatenate` and `ParamSpec`**
<img width="977" height="432" alt="Screenshot from 2026-01-30 12-13-22" src="https://github.com/user-attachments/assets/19742d22-80a9-4de8-b426-66b34569c9ea" />
<img width="406" height="184" alt="Screenshot from 2026-01-30 12-37-43" src="https://github.com/user-attachments/assets/54e3a4a1-ad03-4f83-b626-efd3c01d032a" />
