### PR TITLE
Version check added as Calculator attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add missing pydantic fields for calculation timings (#211)
 - Added `scalmp2c` to `BlockMethod` (#212)
 - Add SCF (spin-)density matrix to `Output` (#204)
+- Add version check attribute to Calculator, which is parsed to get_output (#225)
 
 ### Changed
 - Refactored methods from Runner into BaseRunner (#193)

--- a/src/opi/core.py
+++ b/src/opi/core.py
@@ -39,6 +39,9 @@ class Calculator:
         Can only be disabled after initialization of a `Calculator` (not recommended!).
     _input | input: Input
         Contains all ORCA input parameters except for the primary structural information.
+    version_check: bool, default: True
+        Activates version check when running an ORCA calculation. When running a complete series of input generation, calculation, 
+        and output processing, it overrides the get_output version check attribute.
     """
 
     def __init__(
@@ -94,6 +97,9 @@ class Calculator:
         # ----------------------------
         # > BINARY VERSION CHECK
         # ----------------------------
+
+        self.version_check: bool = version_check
+
         if version_check:
             # > Raises RuntimeError if version is not compatible or cannot be determined.
             self.check_version()
@@ -304,14 +310,19 @@ class Calculator:
         runner = self._create_runner()
         runner.create_jsons(self.basename, force=force)
 
-    def get_output(self) -> "Output":
+    def get_output(self, 
+                   *, 
+                   version_check: bool | None = None) -> "Output":
         """
         Get an instance of `Output` setup for the current job.
         Can be called before execution of job.
         """
+        vc = self.version_check if version_check is None else version_check
+
         return Output(
             basename=self.basename,
             working_dir=self.working_dir,
+            version_check=vc,
         )
 
     def check_version(self) -> None:

--- a/src/opi/core.py
+++ b/src/opi/core.py
@@ -40,8 +40,7 @@ class Calculator:
     _input | input: Input
         Contains all ORCA input parameters except for the primary structural information.
     version_check: bool, default: True
-        Activates version check when running an ORCA calculation. When running a complete series of input generation, calculation,
-        and output processing, it overrides the get_output version check attribute.
+        Enable/disable ORCA binary version check as well as version check on the JSON output.
     """
 
     def __init__(
@@ -100,7 +99,7 @@ class Calculator:
 
         self.version_check: bool = version_check
 
-        if version_check:
+        if self.version_check:
             # > Raises RuntimeError if version is not compatible or cannot be determined.
             self.check_version()
 
@@ -314,6 +313,12 @@ class Calculator:
         """
         Get an instance of `Output` setup for the current job.
         Can be called before execution of job.
+
+        Parameters
+        ----------
+        version_check : bool | None, default=None
+            Whether to perform a version check on the output.
+            If ``None``, the value of ``self.version_check`` is used.
         """
         vc = self.version_check if version_check is None else version_check
 

--- a/src/opi/core.py
+++ b/src/opi/core.py
@@ -318,7 +318,7 @@ class Calculator:
         ----------
         version_check : bool | None, default=None
             Whether to perform a version check on the output.
-            If ``None``, the value of ``self.version_check`` is used.
+            If `None`, the value of `self.version_check` is used.
         """
         vc = self.version_check if version_check is None else version_check
 

--- a/src/opi/core.py
+++ b/src/opi/core.py
@@ -40,7 +40,7 @@ class Calculator:
     _input | input: Input
         Contains all ORCA input parameters except for the primary structural information.
     version_check: bool, default: True
-        Activates version check when running an ORCA calculation. When running a complete series of input generation, calculation, 
+        Activates version check when running an ORCA calculation. When running a complete series of input generation, calculation,
         and output processing, it overrides the get_output version check attribute.
     """
 
@@ -310,9 +310,7 @@ class Calculator:
         runner = self._create_runner()
         runner.create_jsons(self.basename, force=force)
 
-    def get_output(self, 
-                   *, 
-                   version_check: bool | None = None) -> "Output":
+    def get_output(self, *, version_check: bool | None = None) -> "Output":
         """
         Get an instance of `Output` setup for the current job.
         Can be called before execution of job.


### PR DESCRIPTION
## Closes Issues
Closes #223
...

## Description
- Added a version check attribute to the Calculator class. When defined, it also overrides the version check of get_output. 

---

## Release Notes


### Added 

- Add version check attribute to Calculator, which is parsed to get_output
