### PR TITLE
Fixing server utilities

### DIFF
--- a/examples/exmp046_server/job.py
+++ b/examples/exmp046_server/job.py
@@ -28,8 +28,8 @@ server = OpiServer(
 
 # Start server. Change the method to the method that should be used, e.g., AIMNet2 or UMA.
 status = server.start_server(cmd_arguments="method")
-if status != ServerStatus.RUNNING:
-    if status == ServerStatus.ALREADY_RUNNING:
+if status is not ServerStatus.RUNNING:
+    if status is ServerStatus.ALREADY_RUNNING:
         warnings.warn("Some server was already running. Using old one.")
     elif status == ServerStatus.PORT_IN_USE:
         warnings.warn("Port for server in use. Continue on your own risk.")

--- a/examples/exmp046_server/job.py
+++ b/examples/exmp046_server/job.py
@@ -26,8 +26,8 @@ server = OpiServer(
     serverpath="/path/to/working/server/script/from/orca-external-tools"
 )
 
-# Start server
-status = server.start_server(exe="bash")
+# Start server. Change the method to the method that should be used, e.g., AIMNet2 or UMA.
+status = server.start_server(cmd_arguments="method")
 if status != ServerStatus.RUNNING:
     if status == ServerStatus.ALREADY_RUNNING:
         warnings.warn("Some server was already running. Using old one.")

--- a/src/opi/external_methods/server.py
+++ b/src/opi/external_methods/server.py
@@ -113,11 +113,7 @@ class OpiServer:
             # Build the command list:
             # optional exe + [server_script] + -b ID:port + optional args
             cmd = [exe] if exe else []
-            cmd += [
-                self.serverpath,
-                "-b",
-                f"{self._host_id}:{self._port}"
-                ]
+            cmd += [self.serverpath, "-b", f"{self._host_id}:{self._port}"]
             if cmd_arguments:
                 cmd.append(cmd_arguments)
             # Start the server

--- a/src/opi/external_methods/server.py
+++ b/src/opi/external_methods/server.py
@@ -112,9 +112,12 @@ class OpiServer:
             # Therefore, first set up the command line call for the server script
             # Build the command list:
             # optional exe + [server_script] + -b ID:port + optional args
-            cmd = [self.serverpath] if not exe else [exe, self.serverpath]
-            cmd.append("-b")
-            cmd.append(f"{self._host_id}:{self._port}")
+            cmd = [exe] if exe else []
+            cmd += [
+                self.serverpath,
+                "-b",
+                f"{self._host_id}:{self._port}"
+                ]
             if cmd_arguments:
                 cmd.append(cmd_arguments)
             # Start the server

--- a/src/opi/external_methods/server.py
+++ b/src/opi/external_methods/server.py
@@ -84,7 +84,7 @@ class OpiServer:
     def start_server(
         self,
         cmd_arguments: str | None = None,
-        exe: str = sys.executable,
+        exe: str | None = None,
         max_boot_time: float = 20.0,
     ) -> ServerStatus:
         """
@@ -95,7 +95,7 @@ class OpiServer:
         ----------
         cmd_arguments: str | None, default: None
             cmd arguments that should be passed to the server
-        exe: str, default: sys.executable
+        exe: str | None, default: None
             Executable to use for starting the server
         max_boot_time: float, default: 5.0 (sec)
             Maximum time in sec to wait till server is booted
@@ -111,8 +111,8 @@ class OpiServer:
             # Start server by running a python process
             # Therefore, first set up the command line call for the server script
             # Build the command list:
-            # ["python", server_script] + -b ID:port + optional args
-            cmd = [exe, self.serverpath]
+            # optional exe + [server_script] + -b ID:port + optional args
+            cmd = [self.serverpath] if not exe else [exe, self.serverpath]
             cmd.append("-b")
             cmd.append(f"{self._host_id}:{self._port}")
             if cmd_arguments:


### PR DESCRIPTION
## Description
- Adjusting the server functionality to the recent changes of the [oet](https://github.com/faccts/orca-external-tools). Previously, the server was always started with the python version used to execute OPI, which can lead to import errors when calling the `oet` scripts that were installed to a different environment.

---

## Release Notes

### Fixed 
- Adjusted the `server` functionality to work with recent changes in the orca-external-tools infrastructure.
