### PR TITLE
Add RHF and ROHF to get_s2 getter function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `output.error_messages()` which retrieves all error messages from known strings from the ORCA output file (#222).
 - Added `output.cc_converged` and `output.casscf_converged` to check cc and casscf convergence (#222).
 - Added `z_maxiter` to method block for setting the number of CP-SCF iterations (#222).
+- The function output `get_s2` now returns values for RHF/RKS and ROHF/ROKS (#241).
 
 ### Changed
 - Refactored methods from Runner into BaseRunner (#193)

--- a/examples/exmp017_roci/job.py
+++ b/examples/exmp017_roci/job.py
@@ -57,4 +57,15 @@ def run_exmp017(
 
     # > Parse JSON files
     output.parse()
+
+    # > Print S2 values
+    if s2_result := output.get_s2():
+        s2, ideal_s2 = s2_result
+        print(f"expectation S2: {s2}, ideal S**2: {ideal_s2}")
+    else:
+        print(f"Could not retrieve multiplicitiy from ORCA calculation: {output.get_outfile()}")
     return output
+
+
+if __name__ == "__main__":
+    run_exmp017()

--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -1779,26 +1779,47 @@ class Output:
 
     def get_s2(self, *, index: int = -1) -> tuple[StrictFiniteFloat, StrictFiniteFloat] | None:
         """
-        Get the S² expectation value and the ideal S² value by grepping them from the output file.
+        Get the S² expectation value and the ideal S² value by grepping them from the output file for UHF and returning
+        the ideal values for RHF and ROHF.
 
         Parameters
         ----------
         index : int, default: -1
             Index of the geometry for which S² should be returned. The default -1 refers to the final geometry.
             Silently ignores if the requested index is not available and returns None.
+            For RHF/ROHF the index is not relevant since the ideal values are returned.
 
         Returns
         ----------
         tuple[StrictFiniteFloat, StrictFiniteFloat] | None
             Return the expectation value and the ideal value or None if nothing is found.
         """
-        outfile = self.get_outfile()
-        # // String for searching the S² expectation value.
-        expec_string = "Expectation value of <S**2>"
-        # // String for searching the ideal S² value.
-        ideal_string = "Ideal value S*(S+1)"
-        expec_s2 = get_float_from_line(outfile, expec_string, index, strict=False)
-        ideal_s2 = get_float_from_line(outfile, ideal_string, index, strict=False)
+        expec_s2: StrictFiniteFloat | None = None
+        ideal_s2: StrictFiniteFloat | None = None
+        # > Get HFType
+        hftype = self.get_hftype()
+        match hftype:
+            # > RHF/RKS just returns the ideal value zero
+            case Hftyp.RHF:
+                return 0.0, 0.0
+            # > ROHF/ROKS - ideal S2 value by construction
+            case Hftyp.ROHF:
+                mult = self.get_mult()
+                # > Cannot determine S2 without multiplicity
+                if mult:
+                    ideal_s2 = (mult**2 - 1) / 4
+                    expec_s2 = ideal_s2
+            # > For UHF or None we just try to get S2 from the output
+            case Hftyp.UHF | _:
+                # > Grep from output file
+                outfile = self.get_outfile()
+                # // String for searching the S² expectation value.
+                expec_string = "Expectation value of <S**2>"
+                # // String for searching the ideal S² value.
+                ideal_string = "Ideal value S*(S+1)"
+                expec_s2 = get_float_from_line(outfile, expec_string, index, strict=False)
+                ideal_s2 = get_float_from_line(outfile, ideal_string, index, strict=False)
+
         if expec_s2 is not None and ideal_s2 is not None:
             return expec_s2, ideal_s2
         else:

--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -1835,10 +1835,13 @@ class Output:
 
         return pol
 
-    def get_s2(self, *, index: int = -1) -> tuple[StrictFiniteFloat, StrictFiniteFloat] | None:
+    def get_s2(
+        self, *, index: int = -1
+    ) -> tuple[StrictFiniteFloat, StrictFiniteFloat] | tuple[None, None]:
         """
         Get the S² expectation value and the ideal S² value by grepping them from the output file for UHF and returning
-        the ideal values for RHF and ROHF.
+        the ideal values for RHF and ROHF. The ideal value for ROHF requires the multiplicity which is obtained via
+        `self.get_mult()`.
 
         Parameters
         ----------
@@ -1849,7 +1852,7 @@ class Output:
 
         Returns
         ----------
-        tuple[StrictFiniteFloat, StrictFiniteFloat] | None
+        tuple[StrictFiniteFloat, StrictFiniteFloat] | tuple[None, None]
             Return the expectation value and the ideal value or None if nothing is found.
         """
         expec_s2: StrictFiniteFloat | None = None
@@ -1881,7 +1884,7 @@ class Output:
         if expec_s2 is not None and ideal_s2 is not None:
             return expec_s2, ideal_s2
         else:
-            return None
+            return None, None
 
     def get_zpe(self, *, index: int = -1) -> StrictPositiveFloat | None:
         """


### PR DESCRIPTION
## Closes Issues
Closes #239 


## Description
- Add S^2 return value for the simple models RHF (just 0.0) and ROHF (ideal value from the multiplicity) to the getter function `get_s2`

---

## Release Notes

### Added 

- The function output `get_s2` now returns values for RHF/RKS and ROHF/ROKS (#241).
