### PR TITLE
feat: allow invalid output fields to be dropped instead of raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add the keyword `dumpactints` to `BlockOutput` (#245).
 - Added fallback keyword argument for `get_final_energy`, `get_gradient`, and `get_structure` that allows to parse these properties from the `.out` file if no JSON output is available (#237).
 - Added `get_frequencies`, `get_imaginary_frequencies`, `is_pes_minimum`, and `is_pes_transition_state` to the `Output` class (#247).
+- `Output.parse()`, `Output.parse_property()`, `Output.parse_gbw()`, and `Output.__init__()` now accept a `strict` parameter (default True). When set to False, output fields that fail Pydantic validation are silently set to None and a UserWarning is emitted instead of raising a ValidationError (#248).
 
 ### Changed
 - Refactored methods from Runner into BaseRunner (#193)

--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -104,6 +104,7 @@ class Output:
         working_dir: Path | None = None,
         version_check: bool = True,
         parse: bool = False,
+        strict: bool = True,
     ):
         """
         ORCA output parser that is mainly based on the JSON-property and JSON-GBW file.
@@ -124,6 +125,10 @@ class Output:
             True: Create (if turned on by `create_gbw_json/create_property_json`) and parse JSONs files at the end of the initialization.
             False: Only return an Output object. In order to use the object to access the JSON data,
                    `Output.parse()` has to be called first.
+        strict: bool, default: True
+            If True, a ValidationError is raised when any field in the parsed output cannot be validated.
+            If False, fields that fail validation are silently set to None and a UserWarning is emitted.
+            Only takes effect when `parse=True`; otherwise pass `strict` directly to `Output.parse()`.
 
         Raises
         ----------
@@ -157,7 +162,7 @@ class Output:
 
         # // CREATE AND PARSE JSONS FILES
         if parse:
-            self.parse()
+            self.parse(strict=strict)
 
     def parse(
         self,
@@ -165,6 +170,7 @@ class Output:
         do_create_gbw_json: bool | None = None,
         read_prop_json: bool = True,
         read_gbw_json: bool = True,
+        strict: bool = True,
     ) -> None:
         """
         Create and read property- and gbw-JSON file(s) (according to `do_create_property_json` and `do_create_gbw_json`).
@@ -185,6 +191,9 @@ class Output:
             Whether to read the gbw JSON files. If True, the base gbw JSON file and any gbw JSON files from multi gbw
             runs (e.g., scan or neb) will be read. If False, none of these files will be read.
             If any of the JSON files that should be read are not present, a FileNotFoundError is raised.
+        strict: bool, default: True
+            If True, a ValidationError is raised when any field in the parsed output cannot be validated.
+            If False, fields that fail validation are silently set to None and a UserWarning is emitted.
 
         Raises
         ----------
@@ -192,20 +201,22 @@ class Output:
             If any JSON file should be read that is not present.
         """
         if read_prop_json:
-            self.parse_property(do_create_property_json=do_create_property_json)
+            self.parse_property(do_create_property_json=do_create_property_json, strict=strict)
         else:
             # // version check is performed with property JSON
             if self.do_version_check:
                 warn("No version check possible.")
 
         if read_gbw_json:
-            self.parse_gbw(do_create_gbw_json=do_create_gbw_json)
+            self.parse_gbw(do_create_gbw_json=do_create_gbw_json, strict=strict)
 
         # > Redump JSON files
         if self.do_redump_jsons:
             self._redump_jsons()
 
-    def parse_property(self, do_create_property_json: bool | None = None) -> None:
+    def parse_property(
+        self, do_create_property_json: bool | None = None, strict: bool = True
+    ) -> None:
         """
         Create and read property-JSON file.
 
@@ -214,6 +225,9 @@ class Output:
         do_create_property_json: bool | None, default: None
             Whether to create the property JSON file. If None, the file is only created if it is missing. If True,
             the existing file will be overwritten. If False, the file will not be created. Default is None.
+        strict: bool, default: True
+            If True, a ValidationError is raised when any field cannot be validated.
+            If False, fields that fail validation are set to None and a UserWarning is emitted.
         """
         # // Use default name if None was supplied
         if not self.property_json_file:
@@ -229,9 +243,11 @@ class Output:
         # > Check in property JSON whether version fits:
         if self.do_version_check:
             self.check_version()
-        self.results_properties = PropertyResults(**self.property_json_data)
+        self.results_properties = PropertyResults.model_validate(
+            self.property_json_data, context={"strict": strict}
+        )
 
-    def parse_gbw(self, do_create_gbw_json: bool | None = None) -> None:
+    def parse_gbw(self, do_create_gbw_json: bool | None = None, strict: bool = True) -> None:
         """
         Create and read gbw-JSON file(s).
 
@@ -240,6 +256,9 @@ class Output:
         do_create_gbw_json: bool | None, default: None
             Whether to create the gbw JSON files. If None, the files are only created if they are missing. If True,
             the existing files will be overwritten. If False, the files will not be created. Default is None.
+        strict: bool, default: True
+            If True, a ValidationError is raised when any field cannot be validated.
+            If False, fields that fail validation are set to None and a UserWarning is emitted.
         """
         # // Use default names if None was supplied
         if not self.gbw_json_files:
@@ -252,7 +271,10 @@ class Output:
 
         # // read the GBW files
         self.gbw_json_data = self._process_json_files(self.gbw_json_files, continue_on_error=True)
-        self.results_gbw = [GbwResults(**data) for data in self.gbw_json_data]
+        self.results_gbw = [
+            GbwResults.model_validate(data, context={"strict": strict})
+            for data in self.gbw_json_data
+        ]
 
     @property
     def gbw_json_files(self) -> tuple[Path, ...]:

--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -226,8 +226,8 @@ class Output:
             Whether to create the property JSON file. If None, the file is only created if it is missing. If True,
             the existing file will be overwritten. If False, the file will not be created. Default is None.
         strict: bool, default: True
-            If True, a ValidationError is raised when any field cannot be validated.
-            If False, fields that fail validation are set to None and a UserWarning is emitted.
+            If `True`, a `ValidationError` is raised when any field cannot be validated.
+            If `False`, fields that fail validation are set to `None` and a `UserWarning` is emitted.
         """
         # // Use default name if None was supplied
         if not self.property_json_file:

--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -257,8 +257,9 @@ class Output:
             Whether to create the gbw JSON files. If None, the files are only created if they are missing. If True,
             the existing files will be overwritten. If False, the files will not be created. Default is None.
         strict: bool, default: True
-            If True, a ValidationError is raised when any field cannot be validated.
-            If False, fields that fail validation are set to None and a UserWarning is emitted.
+
+            If `True`, a `ValidationError` is raised when any field cannot be validated.
+            If `False`, fields that fail validation are set to `None` and a `UserWarning` is emitted.
         """
         # // Use default names if None was supplied
         if not self.gbw_json_files:

--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -192,8 +192,8 @@ class Output:
             runs (e.g., scan or neb) will be read. If False, none of these files will be read.
             If any of the JSON files that should be read are not present, a FileNotFoundError is raised.
         strict: bool, default: True
-            If True, a ValidationError is raised when any field in the parsed output cannot be validated.
-            If False, fields that fail validation are silently set to None and a UserWarning is emitted.
+            If `True`, a `ValidationError` is raised when any field in the parsed output cannot be validated.
+            If `False`, fields that fail validation are silently set to `None` and a `UserWarning` is emitted.
 
         Raises
         ----------

--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -126,8 +126,8 @@ class Output:
             False: Only return an Output object. In order to use the object to access the JSON data,
                    `Output.parse()` has to be called first.
         strict: bool, default: True
-            If True, a ValidationError is raised when any field in the parsed output cannot be validated.
-            If False, fields that fail validation are silently set to None and a UserWarning is emitted.
+            If `True`, a `ValidationError` is raised when any field in the parsed output cannot be validated.
+            If `False`, fields that fail validation are silently set to `None` and a `UserWarning` is emitted.
             Only takes effect when `parse=True`; otherwise pass `strict` directly to `Output.parse()`.
 
         Raises

--- a/src/opi/output/models/base/get_item.py
+++ b/src/opi/output/models/base/get_item.py
@@ -1,10 +1,12 @@
 import re
 import typing
+import warnings
 from abc import ABC
 from types import UnionType
 from typing import Any, get_args, get_origin
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError, ValidationInfo, model_validator
+from pydantic.functional_validators import ModelWrapValidatorHandler
 
 
 def get_clean_type_name(t: Any) -> str:
@@ -31,6 +33,32 @@ def get_clean_type_name(t: Any) -> str:
 
 class GetItem(BaseModel, ABC):
     """This class contains the get_item function for nearly all other classes"""
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _drop_invalid_fields(
+        cls,
+        data: Any,
+        handler: ModelWrapValidatorHandler["GetItem"],
+        info: ValidationInfo,
+    ) -> "GetItem":
+        try:
+            return handler(data)
+        except ValidationError as e:
+            if (info.context or {}).get("strict", True):
+                raise
+            if not isinstance(data, dict):
+                raise
+            bad_keys = {str(error["loc"][0]) for error in e.errors() if error["loc"]}
+            if not bad_keys:
+                raise
+            cleaned = {k: v for k, v in data.items() if str(k) not in bad_keys}
+            result = handler(cleaned)  # re-raises if required fields are missing
+            warnings.warn(
+                f"{cls.__name__}: dropped fields due to validation errors: {bad_keys}",
+                stacklevel=2,
+            )
+            return result
 
     def __getitem__(self, name: str) -> Any:
         return getattr(self, name.lower())

--- a/src/opi/output/models/base/get_item.py
+++ b/src/opi/output/models/base/get_item.py
@@ -42,9 +42,11 @@ class GetItem(BaseModel, ABC):
         handler: ModelWrapValidatorHandler["GetItem"],
         info: ValidationInfo,
     ) -> "GetItem":
+        # > First try to run core Pydantic validation
         try:
             return handler(data)
         except ValidationError as e:
+            # > Default is strict is set to True and the error is just raised
             if (info.context or {}).get("strict", True):
                 raise
             if not isinstance(data, dict):

--- a/src/opi/output/models/base/get_item.py
+++ b/src/opi/output/models/base/get_item.py
@@ -3,7 +3,7 @@ import typing
 import warnings
 from abc import ABC
 from types import UnionType
-from typing import Any, get_args, get_origin
+from typing import Any, ClassVar, get_args, get_origin
 
 from pydantic import BaseModel, ValidationError, ValidationInfo, model_validator
 from pydantic.functional_validators import ModelWrapValidatorHandler
@@ -32,7 +32,20 @@ def get_clean_type_name(t: Any) -> str:
 
 
 class GetItem(BaseModel, ABC):
-    """This class contains the get_item function for nearly all other classes"""
+    """
+    This class contains the get_item function and is the ABC of the output model classes.
+
+    Attributes
+    -----------
+    strict: bool, default = True
+        Default boolean if no explicit context is given. If True, pydantic validation will raise a `ValidataionError`,
+        if False, the field which caused the validation to fail will be dropped and return to the default Value, which
+        is `None`.
+    """
+
+    strict: ClassVar[bool] = (
+        True  # > Annotated but with ClassVar so that it is not treated as a Pydantic field
+    )
 
     @model_validator(mode="wrap")
     @classmethod
@@ -46,20 +59,24 @@ class GetItem(BaseModel, ABC):
         try:
             return handler(data)
         except ValidationError as e:
-            # > Default is strict is set to True and the error is just raised
-            if (info.context or {}).get("strict", True):
+            # > In strict mode (the default) we don't recover - just raise
+            if (info.context or {}).get("strict", cls.strict):
                 raise
+            # > data to validate should always be a dict since we load it from JSON - defensive check
             if not isinstance(data, dict):
                 raise
+            # > Identify the top-level fields that triggered the ValidationError
             bad_keys = {str(error["loc"][0]) for error in e.errors() if error["loc"]}
+            # > Nothing actionable to drop - re-raise the original error
             if not bad_keys:
                 raise
+            # > Rebuild the input without the offending fields - each dropped field
+            # > falls back to its own default on revalidation - typically None
             cleaned = {k: v for k, v in data.items() if str(k) not in bad_keys}
-            result = handler(cleaned)  # re-raises if required fields are missing
-            warnings.warn(
-                f"{cls.__name__}: dropped fields due to validation errors: {bad_keys}",
-                stacklevel=2,
-            )
+            # > Revalidate - this re-raises if a dropped field was actually required
+            result = handler(cleaned)
+            # > Let the caller know which fields were dropped
+            warnings.warn(f"{cls.__name__}: dropped fields due to validation errors: {bad_keys}")
             return result
 
     def __getitem__(self, name: str) -> Any:

--- a/src/opi/output/models/base/get_item.py
+++ b/src/opi/output/models/base/get_item.py
@@ -33,14 +33,14 @@ def get_clean_type_name(t: Any) -> str:
 
 class GetItem(BaseModel, ABC):
     """
-    This class contains the get_item function and is the ABC of the output model classes.
+    This class contains the `get_item` function and is the ABC of the output model classes.
 
     Attributes
     -----------
     strict: bool, default = True
-        Default boolean if no explicit context is given. If True, pydantic validation will raise a `ValidataionError`,
+        Default boolean if no explicit context is given. If True, pydantic validation will raise a `ValidationError`,
         if False, the field which caused the validation to fail will be dropped and return to the default Value, which
-        is `None`.
+        is typically `None`.
     """
 
     strict: ClassVar[bool] = (

--- a/tests/unit/test_output_partial_validation.py
+++ b/tests/unit/test_output_partial_validation.py
@@ -1,0 +1,57 @@
+import warnings
+
+import pytest
+from pydantic import ValidationError
+
+from opi.output.models.json.property.properties.calc_info import CalcInfo
+from opi.output.models.json.property.property_results import PropertyResults
+
+
+class TestPartialValidation:
+    """Validation failures in individual fields should not abort the whole model."""
+
+    @pytest.mark.unit
+    @pytest.mark.output
+    def test_strict_true_raises(self) -> None:
+        """With strict=True (default), a bad field raises ValidationError."""
+        with pytest.raises(ValidationError):
+            CalcInfo.model_validate({"charge": "not-an-int", "mult": 1}, context={"strict": True})
+
+    @pytest.mark.unit
+    @pytest.mark.output
+    def test_strict_false_drops_field(self) -> None:
+        """With strict=False, a bad field becomes None and a UserWarning is emitted."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = CalcInfo.model_validate(
+                {"charge": "not-an-int", "mult": 1}, context={"strict": False}
+            )
+
+        assert result.charge is None
+        assert result.mult == 1
+        assert any("charge" in str(w.message) for w in caught)
+
+    @pytest.mark.unit
+    @pytest.mark.output
+    def test_valid_fields_unaffected(self) -> None:
+        """Fields that pass validation are still populated normally."""
+        result = CalcInfo.model_validate({"charge": 0, "mult": 1, "numofatoms": 3})
+        assert result.charge == 0
+        assert result.mult == 1
+        assert result.numofatoms == 3
+
+    @pytest.mark.unit
+    @pytest.mark.output
+    def test_nested_invalid_field_becomes_none(self) -> None:
+        """Validation failure in a nested model only drops the failing field there."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = PropertyResults.model_validate(
+                {"calculation_info": {"charge": "bad", "mult": 1}},
+                context={"strict": False},
+            )
+
+        assert result.calculation_info is not None
+        assert result.calculation_info.charge is None
+        assert result.calculation_info.mult == 1
+        assert any("charge" in str(w.message) for w in caught)

--- a/tests/unit/test_output_partial_validation.py
+++ b/tests/unit/test_output_partial_validation.py
@@ -21,6 +21,7 @@ class TestPartialValidation:
     @pytest.mark.output
     def test_strict_false_drops_field(self) -> None:
         """With strict=False, a bad field becomes None and a UserWarning is emitted."""
+        # > Catch the user warning from the validation fallback
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             result = CalcInfo.model_validate(
@@ -29,6 +30,7 @@ class TestPartialValidation:
 
         assert result.charge is None
         assert result.mult == 1
+        # > Check if the discarded field `charge` is in the warning message
         assert any("charge" in str(w.message) for w in caught)
 
     @pytest.mark.unit
@@ -44,6 +46,7 @@ class TestPartialValidation:
     @pytest.mark.output
     def test_nested_invalid_field_becomes_none(self) -> None:
         """Validation failure in a nested model only drops the failing field there."""
+        # > Catch the user warning from the validation fallback
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             result = PropertyResults.model_validate(
@@ -54,4 +57,5 @@ class TestPartialValidation:
         assert result.calculation_info is not None
         assert result.calculation_info.charge is None
         assert result.calculation_info.mult == 1
+        # > Check if the discarded field `charge` is in the warning message
         assert any("charge" in str(w.message) for w in caught)


### PR DESCRIPTION
## Closes Issues
Closes None

## Description
- Adds an optional keyword `strict=True` to `Output.__init__()` and to `Output.parse()` which allows to drop the fields where Pydantic validation fail when it is set to `False`. This way we do not switch the current behavior but have the option for a less strict output generation. 

---

## Release Notes

### Added 

- `Output.parse()`, `Output.parse_property()`, `Output.parse_gbw()`, and `Output.__init__()` now accept a `strict` parameter (default True). When set to False, output fields that fail Pydantic validation are silently set to None and a UserWarning is emitted instead of raising a ValidationError (#248).