### PR TITLE
fix: correct type annotation of `ts_active_atoms` and `ts_active_atoms2` in `BlockGeom`

### DIFF
--- a/src/opi/input/blocks/block_geom.py
+++ b/src/opi/input/blocks/block_geom.py
@@ -1,5 +1,5 @@
 import re
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Sequence
 
 from pydantic import (
     Field,
@@ -726,12 +726,13 @@ class BlockGeom(Block):
 
     @field_validator("ts_active_atoms", "ts_active_atoms2", mode="before")
     @classmethod
-    def ts_active_atoms_init(cls, inp: list[int] | IntGroupEnd) -> IntGroupEnd:
+    def ts_active_atoms_init(cls, inp: Sequence[int] | IntGroupEnd) -> IntGroupEnd:
         """
         Creates IntGroupEnd object by parsing given list of integers
+
         Parameters
         ----------
-        inp : list[int] | IntGroupEnd
+        inp : Sequence[int] | IntGroupEnd
 
         Returns
         -------

--- a/src/opi/input/blocks/block_geom.py
+++ b/src/opi/input/blocks/block_geom.py
@@ -12,6 +12,7 @@ from opi.input.blocks import Block
 from opi.input.blocks.fragment import FragList, Fragment, Frags
 from opi.input.blocks.geom_wrapper import GeomWrapper, GeomWrapperBox
 from opi.input.blocks.util import InputFilePath, NumList
+from opi.models import IntGroupEnd
 from opi.utils.element import Element
 from opi.utils.misc import FLOAT_REGEX
 
@@ -609,8 +610,8 @@ class BlockGeom(Block):
     optelement: Element | None = None
     hybridhess: Hybrid | None = None
     hybridhess_core: Hybrid | None = None
-    ts_active_atoms: Hybrid | None = None
-    ts_active_atoms2: Hybrid | None = None
+    ts_active_atoms: IntGroupEnd | None = None
+    ts_active_atoms2: IntGroupEnd | None = None
     constraints: Constraints | None = None
     potentials: Potential | None = None
     scan: Scan | None = None
@@ -722,6 +723,26 @@ class BlockGeom(Block):
                 raise ValueError(f"Failed to parse constraints: {e}")
 
             return ConnectFragments(constraints=fragconstraints)
+
+    @field_validator("ts_active_atoms", "ts_active_atoms2", mode="before")
+    @classmethod
+    def ts_active_atoms_init(cls, inp: list[int] | IntGroupEnd) -> IntGroupEnd:
+        """
+        Creates IntGroupEnd object by parsing given list of integers
+        Parameters
+        ----------
+        inp : list[int] | IntGroupEnd
+
+        Returns
+        -------
+        IntGroupEnd
+            IntGroupEnd object
+
+        """
+        if isinstance(inp, IntGroupEnd):
+            return inp
+        else:
+            return IntGroupEnd(values=inp)
 
     @field_validator(
         "rigidfrags",

--- a/src/opi/models/intgroup.py
+++ b/src/opi/models/intgroup.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Self
 
 from pydantic import BaseModel
@@ -38,13 +39,13 @@ class IntGroup(BaseModel):
         return f"{{ {' '.join(parts)} }}"
 
     @classmethod
-    def init(cls, inp: str | list[int | tuple[int, int]] | list[int]) -> Self:
+    def init(cls, inp: str | Sequence[int | tuple[int, int]]) -> Self:
         """
         Initialize `IntGroup` from a string or list.
 
         Parameters
         ----------
-        inp : str | list[int | tuple[int, int]]
+        inp : str | Sequence[int | tuple[int, int]]
             String format example: "{1 2 3:5 10}" or list of ints/tuples.
             Ranges like '4:10' are converted to (4, 10).
             Curly braces in strings are optional and stripped.
@@ -54,8 +55,8 @@ class IntGroup(BaseModel):
         IntGroup
             An object of `IntGroup`.
         """
-        if isinstance(inp, list):
-            return cls(values=inp)
+        if not isinstance(inp, str):
+            return cls(values=list(inp))
         else:
             # > Removing optional leading and trailing curly braces and redundant whitespaces for streamlined processing.
             cleaned_string = inp.strip().removeprefix("{").removesuffix("}").strip()


### PR DESCRIPTION
## Closes Issues
Closes #233
...

## Description
- Correct type annotation `ts_active_atoms` and `ts_active_atoms2`

---

## Release Notes
(Project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); Every entry should start in upper-case and end with `(#<pr-id>)`; Remove sections that don't apply)

### Added
- Add `ts_active_atoms_init()` to allow user to initialize `IntGroupEnd` object for `ts_active_atoms` using just a list.(#233)
 
### Fixed 

- Fix type annotations of `ts_active_atoms` and `ts_active_atoms2` in `BlockGeom`(#233)
