### PR TITLE
feat(GbwResults): add `from_file()` and `get_structure()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - `Structure.from_ase()` now falls back to the `charge` and `spin` entries of `Atoms.info` if ASE's per-atom `initial_charges` / `initial_magnetic_moments` arrays are unset (#273)
 - Add `Block` to allow for creation of arbitrary blocks. (#276)
 - Add functionality to fetch, search or remove a block using the ORCA name of the block. (#276)
-- Added `GbwResults.get_structure()`, `GbwResults.from_gbw_file()`, and `Output.get_structure_from_gbw()` to obtain a `Structure` from a gbw file or gbw JSON (#XXX).
+- Added `GbwResults.get_structure()`, `GbwResults.from_gbw_file()`, and `Output.get_structure_from_gbw()` to obtain a `Structure` from a gbw file or gbw JSON (#280).
 
 ### Changed
 - Refactored methods from Runner into BaseRunner (#193)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - `Structure.from_ase()` now falls back to the `charge` and `spin` entries of `Atoms.info` if ASE's per-atom `initial_charges` / `initial_magnetic_moments` arrays are unset (#273)
 - Add `Block` to allow for creation of arbitrary blocks. (#276)
 - Add functionality to fetch, search or remove a block using the ORCA name of the block. (#276)
+- Added `GbwResults.get_structure()`, `GbwResults.from_gbw_file()`, and `Output.get_structure_from_gbw()` to obtain a `Structure` from a gbw file or gbw JSON (#XXX).
 
 ### Changed
 - Refactored methods from Runner into BaseRunner (#193)

--- a/examples/exmp003_opt/job.py
+++ b/examples/exmp003_opt/job.py
@@ -8,6 +8,7 @@ from opi.core import Calculator
 from opi.input.simple_keywords import Dft, Scf, Task
 from opi.input.structures import Structure
 from opi.output.core import Output
+from opi.output.models.json.gbw.gbw_results import GbwResults
 
 
 def run_exmp003(
@@ -78,6 +79,18 @@ def run_exmp003(
     # > Now we print the final structure as xyz file
     optimized = output.get_structure()
     print(optimized.to_xyz_block())
+
+    # > The final structure is also stored in the gbw file, so it can be obtained from there
+    # > instead of from the property JSON.
+    from_gbw = output.get_structure_from_gbw()
+    print("RMSD between the structure from the property JSON and from the gbw JSON")
+    print(optimized.rmsd(from_gbw))
+
+    # > This also works with nothing but the gbw file at hand, i.e. without an `Output` object.
+    # > The gbw file is converted to JSON with `orca_2json` on the fly.
+    standalone = GbwResults.from_gbw_file(working_dir / "job.gbw").get_structure()
+    print("STRUCTURE FROM GBW FILE")
+    print(standalone.to_xyz_block())
 
     # > Now we print the last gradient calculated which is for
     # > the structure one step before the final structure

--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -1503,6 +1503,36 @@ class Output:
             structure.multiplicity = mult
         return structure
 
+    def get_structure_from_gbw(self, *, index: int = 0) -> Structure | None:
+        """
+        Returns the structure stored in a gbw file as `Structure` object.
+        Silently returns None if no structure is available.
+
+        In contrast to `get_structure()`, which reads the geometry from the property JSON, this
+        getter uses the gbw JSON. It therefore offers no fragment IDs and no `.out` file fallback,
+        but it does distinguish ghost atoms from real ones.
+
+        Parameters
+        ----------
+        index : int, default: 0
+            Index (>= 0) of the gbw file in `self.results_gbw`. The default 0 refers to the main
+            gbw file.
+
+        Returns
+        ----------
+        structure: Structure | None
+            Structure generated from the gbw data or None if no structure is available.
+        """
+        results_gbw = self._safe_get("results_gbw", index)
+        if results_gbw is None:
+            return None
+
+        try:
+            return cast(GbwResults, results_gbw).get_structure()
+        except ValueError:
+            # > `GbwResults.get_structure()` raises on malformed atom data
+            return None
+
     def _get_cartesians(
         self, index: int, /
     ) -> list[tuple[StrictStr, StrictFiniteFloat, StrictFiniteFloat, StrictFiniteFloat]] | None:

--- a/src/opi/output/models/json/gbw/gbw_results.py
+++ b/src/opi/output/models/json/gbw/gbw_results.py
@@ -1,9 +1,17 @@
+from pathlib import Path
+
 from pydantic import Field
 
+from opi.execution.core import Runner
+from opi.input.structures.atom import Atom, GhostAtom
+from opi.input.structures.coordinates import Coordinates
+from opi.input.structures.structure import Structure
+from opi.output.gbw_suffix import GbwSuffix
 from opi.output.models.json.gbw.properties.cite import Cite
 from opi.output.models.json.gbw.properties.header import OrcaHeader
 from opi.output.models.json.gbw.properties.molecule import Molecule
 from opi.output.models.json_loadable import JSONLoadable
+from opi.utils.element import Element
 
 
 class GbwResults(JSONLoadable):
@@ -26,3 +34,120 @@ class GbwResults(JSONLoadable):
 
     class Configuration:
         allow_population_by_field_name = True
+
+    @classmethod
+    def from_gbw_file(
+        cls,
+        gbw_file: Path | str,
+        /,
+        *,
+        force: bool = False,
+        config: dict[str, bool | str | list[str | int]] | None = None,
+    ) -> "GbwResults":
+        """
+        Creates an object from a binary gbw file by converting it with `orca_2json` first.
+
+        This requires a working ORCA installation. The JSON file created by `orca_2json` is written
+        next to `gbw_file` as `<basename>.json`, just like `Output` does. For a ".gbw" file an
+        already existing JSON is reused unless `force` is given. For the other gbw suffixes
+        (".loc", ".qro", ...) the JSON is always recreated, since `orca_2json` maps all of them
+        onto the same file name.
+
+        Parameters
+        ----------
+        gbw_file : Path | str
+            Path to the binary gbw file.
+        force : bool, default: False
+            Recreate the JSON file even if it already exists.
+        config : dict[str, bool | str | list[str | int]] | None, default: None
+            Determine contents of the gbw-JSON file.
+            For details about the configuration refer to the ORCA manual "9.3.2 Configuration file"
+
+        Returns
+        -------
+        GbwResults
+            Object created from the gbw file.
+
+        Raises
+        ------
+        FileNotFoundError
+            Raised if `gbw_file` does not point to a file, or if `orca_2json` did not create a JSON
+            file.
+        ValueError
+            Raised if the created JSON is invalid.
+        """
+        gbw_file = Path(gbw_file).expanduser().resolve()
+        if not gbw_file.is_file():
+            raise FileNotFoundError(f"File {gbw_file} not found")
+
+        # > `orca_2json` maps every binary suffix onto the same "<basename>.json". Reusing an
+        # > existing JSON is therefore only safe for ".gbw" itself, otherwise we could pick up the
+        # > JSON belonging to a different binary (e.g. "job.gbw" when asked for "job.loc").
+        force = force or gbw_file.suffix != GbwSuffix.GBW.value
+
+        runner = Runner(working_dir=gbw_file.parent)
+        runner.create_gbw_json(gbw_file.stem, force=force, config=config, suffix=gbw_file.suffix)
+
+        # > `orca_2json` does not signal failure through its return code, so a missing JSON file is
+        # > the only indication that the conversion did not work.
+        gbw_json_file = gbw_file.with_suffix(".json")
+        if not gbw_json_file.is_file():
+            raise FileNotFoundError(
+                f"orca_2json did not create {gbw_json_file} from {gbw_file}. "
+                "The gbw file may be corrupt or written by an incompatible ORCA version."
+            )
+
+        return cls.from_json_file(gbw_json_file)
+
+    def get_structure(self) -> Structure | None:
+        """
+        Returns the molecular structure stored in the gbw file as `Structure` object.
+        Silently returns None if no structure is available.
+
+        Atoms carrying basis functions but no nuclear charge are returned as `GhostAtom`.
+
+        Returns
+        -------
+        structure: Structure | None
+            Structure generated from the gbw data or None if no structure is available.
+
+        Raises
+        ------
+        ValueError
+            Raised if an atom entry is present but lacks a usable element or coordinates.
+        """
+        molecule = self.molecule
+        if molecule is None or not molecule.atoms:
+            return None
+
+        atoms: list[Atom] = []
+        for gbw_atom in molecule.atoms:
+            # > Determine the element, preferably from the atomic number.
+            if gbw_atom.elementnumber is not None:
+                element = Element.from_atomic_number(gbw_atom.elementnumber)
+            elif gbw_atom.elementlabel is not None:
+                element = Element(gbw_atom.elementlabel)
+            else:
+                raise ValueError("Atom in gbw data has neither an element number nor a label")
+
+            # > Unlike the cartesians in the property JSON, gbw coordinates are already in Angstrom.
+            coords = gbw_atom.coords
+            if coords is None or len(coords) != 3:
+                raise ValueError(f"Atom {element} in gbw data has invalid coordinates: {coords}")
+            coordinates = Coordinates((coords[0], coords[1], coords[2]))
+
+            # > A ghost atom carries basis functions but no nuclear charge. Atoms with an ECP keep
+            # > their effective charge (e.g. 6.0 for oxygen), so they are never mistaken for one.
+            is_ghost = gbw_atom.nuclearcharge == 0.0 and element != Element.X
+            atom_type = GhostAtom if is_ghost else Atom
+            atoms.append(atom_type(element=element, coordinates=coordinates))
+
+        structure = Structure(
+            atoms,
+            charge=molecule.charge if molecule.charge is not None else 0,
+            multiplicity=molecule.multiplicity if molecule.multiplicity is not None else 1,
+        )
+        if molecule.basename:
+            structure.origin = molecule.basename
+
+        return structure

--- a/src/opi/output/models/json/gbw/gbw_results.py
+++ b/src/opi/output/models/json/gbw/gbw_results.py
@@ -6,7 +6,6 @@ from opi.execution.core import Runner
 from opi.input.structures.atom import Atom, GhostAtom
 from opi.input.structures.coordinates import Coordinates
 from opi.input.structures.structure import Structure
-from opi.output.gbw_suffix import GbwSuffix
 from opi.output.models.json.gbw.properties.cite import Cite
 from opi.output.models.json.gbw.properties.header import OrcaHeader
 from opi.output.models.json.gbw.properties.molecule import Molecule
@@ -41,7 +40,7 @@ class GbwResults(JSONLoadable):
         gbw_file: Path | str,
         /,
         *,
-        force: bool = False,
+        reuse_json: bool = False,
         config: dict[str, bool | str | list[str | int]] | None = None,
     ) -> "GbwResults":
         """
@@ -57,11 +56,10 @@ class GbwResults(JSONLoadable):
         ----------
         gbw_file : Path | str
             Path to the binary gbw file.
-        force : bool, default: False
-            Recreate the JSON file even if it already exists.
+        reuse_json : bool, default: False
+            Whether to use an existing json file or create a new one.
         config : dict[str, bool | str | list[str | int]] | None, default: None
-            Determine contents of the gbw-JSON file.
-            For details about the configuration refer to the ORCA manual "9.3.2 Configuration file"
+            Determine contents of the gbw-JSON file. Does nothing if the JSON file is reused and not re-created
 
         Returns
         -------
@@ -80,10 +78,7 @@ class GbwResults(JSONLoadable):
         if not gbw_file.is_file():
             raise FileNotFoundError(f"File {gbw_file} not found")
 
-        # > `orca_2json` maps every binary suffix onto the same "<basename>.json". Reusing an
-        # > existing JSON is therefore only safe for ".gbw" itself, otherwise we could pick up the
-        # > JSON belonging to a different binary (e.g. "job.gbw" when asked for "job.loc").
-        force = force or gbw_file.suffix != GbwSuffix.GBW.value
+        force = not reuse_json
 
         runner = Runner(working_dir=gbw_file.parent)
         runner.create_gbw_json(gbw_file.stem, force=force, config=config, suffix=gbw_file.suffix)

--- a/src/opi/output/models/json/gbw/gbw_results.py
+++ b/src/opi/output/models/json/gbw/gbw_results.py
@@ -44,22 +44,16 @@ class GbwResults(JSONLoadable):
         config: dict[str, bool | str | list[str | int]] | None = None,
     ) -> "GbwResults":
         """
-        Creates an object from a binary gbw file by converting it with `orca_2json` first.
-
-        This requires a working ORCA installation. The JSON file created by `orca_2json` is written
-        next to `gbw_file` as `<basename>.json`, just like `Output` does. For a ".gbw" file an
-        already existing JSON is reused unless `force` is given. For the other gbw suffixes
-        (".loc", ".qro", ...) the JSON is always recreated, since `orca_2json` maps all of them
-        onto the same file name.
+        Creates an object from a binary gbw file by converting it with `orca_2json` and initializing from the `.json` file.
 
         Parameters
         ----------
         gbw_file : Path | str
             Path to the binary gbw file.
         reuse_json : bool, default: False
-            Whether to use an existing json file or create a new one.
+            If True, an existing gbw-JSON file is used.
         config : dict[str, bool | str | list[str | int]] | None, default: None
-            Determine contents of the gbw-JSON file. Does nothing if the JSON file is reused and not re-created
+            Determine contents of the gbw-JSON file. Does nothing if the JSON file is reused and not re-created.
 
         Returns
         -------

--- a/tests/examples/test_exmp003_opt.py
+++ b/tests/examples/test_exmp003_opt.py
@@ -49,6 +49,6 @@ def test_exmp003_opt(
 
     # > Recreating the JSON from the binary gbw file must give the same structure again.
     # > Done after the exports so that the committed fixtures stay untouched by it.
-    recreated = GbwResults.from_gbw_file(tmp_path / "job.gbw", force=True).get_structure()
+    recreated = GbwResults.from_gbw_file(tmp_path / "job.gbw").get_structure()
     assert recreated is not None
     assert recreated.rmsd(from_gbw) == pytest.approx(0.0, abs=1e-6)

--- a/tests/examples/test_exmp003_opt.py
+++ b/tests/examples/test_exmp003_opt.py
@@ -2,6 +2,8 @@ import pytest
 
 from examples.exmp003_opt.job import run_exmp003
 from opi.input.structures import Structure
+from opi.input.structures.atom import Atom
+from opi.output.models.json.gbw.gbw_results import GbwResults
 from tests.helpers import OutFileExporter
 
 
@@ -26,8 +28,27 @@ def test_exmp003_opt(
     structure = output.get_structure()
     assert isinstance(structure, Structure), f"Expected Structure, got {type(structure).__name__}"
 
+    # > Assert that the gbw JSON yields the same structure as the property JSON
+    from_gbw = output.get_structure_from_gbw()
+    assert isinstance(from_gbw, Structure), f"Expected Structure, got {type(from_gbw).__name__}"
+    assert [atom.element for atom in from_gbw.atoms] == [atom.element for atom in structure.atoms]
+    assert from_gbw.charge == structure.charge
+    assert from_gbw.multiplicity == structure.multiplicity
+    for gbw_atom, prop_atom in zip(from_gbw.atoms, structure.atoms):
+        assert gbw_atom.coordinates.to_list() == pytest.approx(
+            prop_atom.coordinates.to_list(), abs=1e-6
+        )
+    # > wB97X-3c puts an ECP on oxygen, which must not be mistaken for a ghost atom
+    assert all(type(atom) is Atom for atom in from_gbw.atoms)
+
     # optional export of json files
     json_files_exporter.export_jsons_from(tmp_path)
 
     # optional export of .out fixture
     out_file_exporter.export_from(tmp_path / "job.out")
+
+    # > Recreating the JSON from the binary gbw file must give the same structure again.
+    # > Done after the exports so that the committed fixtures stay untouched by it.
+    recreated = GbwResults.from_gbw_file(tmp_path / "job.gbw", force=True).get_structure()
+    assert recreated is not None
+    assert recreated.rmsd(from_gbw) == pytest.approx(0.0, abs=1e-6)


### PR DESCRIPTION
## Closes Issues
Closes None


## Description
- Adds `get_structure()` and `from_file()` to `GbwResults`. This makes it easier to improve a single gbw file and it allows simple access to the structure when no property file is present. The gbw structure is also exposed via `Output.get_structure_from_gbw()`

---

## Release Notes

### Added 

- Added `GbwResults.get_structure()`, `GbwResults.from_gbw_file()`, and `Output.get_structure_from_gbw()` to obtain a `Structure` from a gbw file or gbw JSON (#280).
