### PR TITLE
fix: add guideline in CONTRIBUTING.md about stale PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,3 +47,6 @@ After submitting the pull request, you will be asked in the PR thread to sign
 a [CLA](CLA.md) with your GitHub account.  
 We will review the code as soon as possible, provide feedback, and  
 you will then be able to merge the code.
+
+External pull requests that receive no updates within 60 days of the last review  
+will be marked as stale.


### PR DESCRIPTION
## Closes Issues
Closes None

## Description
Add guideline in `CONTRIBUTING.md`  about PRs that have not been updated since 60 days of last review will be marked as stale.

