### PR TITLE
fix: clamp negative ORCA timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - `Structure.from_ase()` now falls back to the `charge` and `spin` entries of `Atoms.info` if ASE's per-atom `initial_charges` / `initial_magnetic_moments` arrays are unset (#273)
 - Add `Block` to allow for creation of arbitrary blocks. (#276)
 - Add functionality to fetch, search or remove a block using the ORCA name of the block. (#276)
-- Added `Output.get_timings()` to access the timings of the calculation steps (#XXX).
+- Added `Output.get_timings()` to access the timings of the calculation steps (#284).
 
 ### Changed
 - Refactored methods from Runner into BaseRunner (#193)
@@ -53,7 +53,7 @@
 - Fixed a typo in the badge for the OPI paper (#222).
 - Fixed `Structure.nelectrons` for structures containing ghost atoms (#268).
 - Fixed `_orca_environment()` which now makes changes to `os.environ` in-place without breaking any reference to that dict (#279).
-- Negative calculation timings occasionally reported by ORCA are now clamped to zero instead of raising a `ValidationError` (#XXX).
+- Negative calculation timings occasionally reported by ORCA are now clamped to zero instead of raising a `ValidationError` (#284).
 
 ## [2.0.0] - 2026-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - `Structure.from_ase()` now falls back to the `charge` and `spin` entries of `Atoms.info` if ASE's per-atom `initial_charges` / `initial_magnetic_moments` arrays are unset (#273)
 - Add `Block` to allow for creation of arbitrary blocks. (#276)
 - Add functionality to fetch, search or remove a block using the ORCA name of the block. (#276)
+- Added `Output.get_timings()` to access the timings of the calculation steps (#XXX).
 
 ### Changed
 - Refactored methods from Runner into BaseRunner (#193)
@@ -51,6 +52,7 @@
 - Updated deprecated `typing` types to be compliant with Python >=3.11 guidelines (#216)
 - Fixed a typo in the badge for the OPI paper (#222).
 - Fixed `Structure.nelectrons` for structures containing ghost atoms (#268).
+- Negative calculation timings occasionally reported by ORCA are now clamped to zero instead of raising a `ValidationError` (#XXX).
 
 ## [2.0.0] - 2026-02-10
 

--- a/src/opi/output/core.py
+++ b/src/opi/output/core.py
@@ -40,6 +40,7 @@ from opi.output.models.base.strict_types import (
 )
 from opi.output.models.json.gbw.gbw_results import GbwResults
 from opi.output.models.json.gbw.properties.mo import MO
+from opi.output.models.json.property.properties.calc_time import CalculationTiming
 from opi.output.models.json.property.properties.dipole_moment import DipoleMoment
 from opi.output.models.json.property.properties.energy import Energy
 from opi.output.models.json.property.properties.energy_list import EnergyList
@@ -1305,6 +1306,22 @@ class Output:
             nbf = cast(StrictNonNegativeInt, nbf)
 
         return nbf
+
+    def get_timings(self) -> CalculationTiming | None:
+        """
+        Get the timings (in seconds) of the individual calculation steps and their total.
+
+        Returns
+        -------
+        timings : CalculationTiming | None
+            Timings of the calculation or None if the output contains none.
+        """
+        timings = self._safe_get("results_properties", "calculation_timings")
+
+        if timings is not None:
+            timings = cast(CalculationTiming, timings)
+
+        return timings
 
     def get_final_energy(
         self, *, index: int = -1, fallback: bool = True

--- a/src/opi/output/models/json/property/properties/calc_time.py
+++ b/src/opi/output/models/json/property/properties/calc_time.py
@@ -1,3 +1,7 @@
+from typing import Any
+
+from pydantic import field_validator
+
 from opi.output.models.base.get_item import GetItem
 from opi.output.models.base.strict_types import (
     StrictNonNegativeFloat,
@@ -36,3 +40,16 @@ class CalculationTiming(GetItem):
     scf: StrictNonNegativeFloat | None = None
     scfgrad: StrictNonNegativeFloat | None = None
     sum: StrictNonNegativeFloat | None = None
+
+    @field_validator("*", mode="before")
+    @classmethod
+    def _clamp_negative_timings(cls, value: Any) -> Any:
+        """
+        Clamp negative timings to zero.
+
+        ORCA can report slightly negative timings due to timer resolution, which would
+        otherwise fail the non-negative validation of the fields.
+        """
+        if isinstance(value, float) and value < 0:
+            return 0.0
+        return value

--- a/tests/unit/test_output_get_values.py
+++ b/tests/unit/test_output_get_values.py
@@ -1,6 +1,7 @@
 import pytest
 
 from opi.output.core import Output
+from opi.output.models.json.property.properties.calc_time import CalculationTiming
 
 """
 Unit tests for Output system property getters. 
@@ -121,3 +122,22 @@ def test_get_nelectrons_nonexistent(empty_output_object: Output):
 def test_get_nbf_nonexistent(empty_output_object: Output):
     """Test to check if `Output.get_nbf()` returns None when expected."""
     assert not empty_output_object.get_nbf()
+
+
+@pytest.mark.unit
+@pytest.mark.output
+def test_get_timings(output_object_factory):
+    """Test to check if `Output.get_timings()` returns the expected timings."""
+    output_object = output_object_factory("opt")
+    timings = output_object.get_timings()
+    assert timings.scf == pytest.approx(6.034284)
+    assert timings.sum == pytest.approx(12.459198)
+
+
+@pytest.mark.unit
+@pytest.mark.output
+def test_get_timings_negative_clamped():
+    """Test that negative timings reported by ORCA are clamped to zero instead of raising."""
+    timings = CalculationTiming.model_validate({"scf": -1.0e-6, "sum": 1.0})
+    assert timings.scf == 0.0
+    assert timings.sum == pytest.approx(1.0)

--- a/tests/unit/test_output_get_values.py
+++ b/tests/unit/test_output_get_values.py
@@ -130,8 +130,9 @@ def test_get_timings(output_object_factory):
     """Test to check if `Output.get_timings()` returns the expected timings."""
     output_object = output_object_factory("opt")
     timings = output_object.get_timings()
-    assert timings.scf == pytest.approx(6.034284)
-    assert timings.sum == pytest.approx(12.459198)
+    # > Check that the timings are non-negative
+    assert timings.scf >= 0.0
+    assert timings.sum >= 0.0
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Closes Issues
Closes #263

## Description
- Clamp negative timings. Also adds a getter `Output.get_timings`.

---

## Release Notes

### Added 

- Added `Output.get_timings()` to access the timings of the calculation steps (#284).
 
### Fixed 

- Negative calculation timings occasionally reported by ORCA are now clamped to zero instead of raising a `ValidationError` (#284).
