### PR TITLE
feat: add input merge logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - Added `GbwResults.get_structure()`, `GbwResults.from_gbw_file()`, and `Output.get_structure_from_gbw()` to obtain a `Structure` from a gbw file or gbw JSON (#280).
 - Added `Output.get_timings()` to access the timings of the calculation steps (#284).
 - Add merge logic for two blocks that model the same ORCA block, via `BlockABC.__or__()`: fields and arbitrary options of both blocks are combined, with the right-hand block taking precedence. Merging two blocks that model different ORCA blocks raises a `ValueError`. (#274)
-- Add merge logic for two `Input` objects, via `Input.__or__()`: simple keywords are combined without duplicates, blocks that model the same ORCA block are merged, arbitrary strings are concatenated, and `ncores`, `memory` and `moinp` are taken from the right-hand input if set. The right-hand input takes precedence throughout, blocks are copied into the result, and neither operand is modified. (#288)
+- Add merge logic for two `Input` objects, via `Input.__or__()`: simple keywords are concatenated without duplicates, keeping their order with those of the left-hand input first, blocks that model the same ORCA block are merged, arbitrary strings are concatenated, and `ncores`, `memory` and `moinp` are taken from the right-hand input if set. The right-hand input takes precedence throughout, blocks are copied into the result, and neither operand is modified. (#288)
 
 
 ### Changed
@@ -48,6 +48,7 @@
 - `Input` now stores blocks under the name of the ORCA block they model instead of under their `BlockABC` class. Hence `Input.blocks` and the dictionary returned by `Input.get_blocks()` are keyed by that name, e.g. `calc.input.get_blocks(BlockScf)["scf"]`. (#276)
 - Change `Input.add_blocks()` to merge two block instances of same type by default, instead of being a no-op. (#274)
 - `Input.add_arbitrary_string()` now also accepts an `ArbitraryString` instance next to a plain `str`, so that an arbitrary string can be added together with the position it carries. (#288)
+- `SimpleKeyword` now compares equal case-insensitively, matching `SimpleKeyword.format_orca()`, which lowercases the keyword, and ORCA itself, which ignores the case. Hence keywords that only differ in case count as duplicates of each other in `Input.add_simple_keywords()`, `Input.remove_simple_keywords()`, `Input.has_simple_keyword()` and `Input.get_simple_keyword()`. (#288)
 
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Added `GbwResults.get_structure()`, `GbwResults.from_gbw_file()`, and `Output.get_structure_from_gbw()` to obtain a `Structure` from a gbw file or gbw JSON (#280).
 - Added `Output.get_timings()` to access the timings of the calculation steps (#284).
 - Add merge logic for two blocks that model the same ORCA block, via `BlockABC.__or__()`: fields and arbitrary options of both blocks are combined, with the right-hand block taking precedence. Merging two blocks that model different ORCA blocks raises a `ValueError`. (#274)
+- Add merge logic for two `Input` objects, via `Input.__or__()`: simple keywords are combined without duplicates, blocks that model the same ORCA block are merged, arbitrary strings are concatenated, and `ncores`, `memory` and `moinp` are taken from the right-hand input if set. The right-hand input takes precedence throughout, blocks are copied into the result, and neither operand is modified.
 
 
 ### Changed
@@ -46,6 +47,7 @@
 - Updated unit conversion constants to be consistent with ORCA (#269).
 - `Input` now stores blocks under the name of the ORCA block they model instead of under their `BlockABC` class. Hence `Input.blocks` and the dictionary returned by `Input.get_blocks()` are keyed by that name, e.g. `calc.input.get_blocks(BlockScf)["scf"]`. (#276)
 - Change `Input.add_blocks()` to merge two block instances of same type by default, instead of being a no-op. (#274)
+- `Input.add_arbitrary_string()` now also accepts an `ArbitraryString` instance next to a plain `str`, so that an arbitrary string can be added together with the position it carries. 
 
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - Added `GbwResults.get_structure()`, `GbwResults.from_gbw_file()`, and `Output.get_structure_from_gbw()` to obtain a `Structure` from a gbw file or gbw JSON (#280).
 - Added `Output.get_timings()` to access the timings of the calculation steps (#284).
 - Add merge logic for two blocks that model the same ORCA block, via `BlockABC.__or__()`: fields and arbitrary options of both blocks are combined, with the right-hand block taking precedence. Merging two blocks that model different ORCA blocks raises a `ValueError`. (#274)
-- Add merge logic for two `Input` objects, via `Input.__or__()`: simple keywords are combined without duplicates, blocks that model the same ORCA block are merged, arbitrary strings are concatenated, and `ncores`, `memory` and `moinp` are taken from the right-hand input if set. The right-hand input takes precedence throughout, blocks are copied into the result, and neither operand is modified.
+- Add merge logic for two `Input` objects, via `Input.__or__()`: simple keywords are combined without duplicates, blocks that model the same ORCA block are merged, arbitrary strings are concatenated, and `ncores`, `memory` and `moinp` are taken from the right-hand input if set. The right-hand input takes precedence throughout, blocks are copied into the result, and neither operand is modified. (#288)
 
 
 ### Changed
@@ -47,7 +47,7 @@
 - Updated unit conversion constants to be consistent with ORCA (#269).
 - `Input` now stores blocks under the name of the ORCA block they model instead of under their `BlockABC` class. Hence `Input.blocks` and the dictionary returned by `Input.get_blocks()` are keyed by that name, e.g. `calc.input.get_blocks(BlockScf)["scf"]`. (#276)
 - Change `Input.add_blocks()` to merge two block instances of same type by default, instead of being a no-op. (#274)
-- `Input.add_arbitrary_string()` now also accepts an `ArbitraryString` instance next to a plain `str`, so that an arbitrary string can be added together with the position it carries. 
+- `Input.add_arbitrary_string()` now also accepts an `ArbitraryString` instance next to a plain `str`, so that an arbitrary string can be added together with the position it carries. (#288)
 
 ### Deprecated
 ### Removed

--- a/src/opi/input/core.py
+++ b/src/opi/input/core.py
@@ -842,23 +842,26 @@ class Input:
     # > ARBITRARY STRINGS
     # ----------------------------------------------------------------------
     def add_arbitrary_string(
-        self, string: str, /, *, pos: ArbitraryStringPos | str | None = None
+        self, string: str | ArbitraryString, /, *, pos: ArbitraryStringPos | str | None = None
     ) -> None:
         """
         Add an arbitrary string.
 
         Parameters
         ----------
-        string : str
+        string : str | ArbitraryString
             Arbitrary string to be added
         pos : ArbitraryStringPos | str | None, default: None
             Coordinates of the arbitrary string within the input file.
             For details look into the `ArbitraryStringPos` class.
         """
+        if isinstance(string, ArbitraryString):
+            arb_string = string
+        else:
+            arb_string = ArbitraryString(string=string)
+            if pos is not None:
+                arb_string.pos = ArbitraryStringPos(pos)
 
-        arb_string = ArbitraryString(string=string)
-        if pos is not None:
-            arb_string.pos = ArbitraryStringPos(pos)
         self._arbitrary_strings.append(arb_string)
 
     def remove_arbitrary_string(
@@ -907,3 +910,72 @@ class Input:
                 raise ValueError("No arbitrary strings added.")
         else:
             self._arbitrary_strings.clear()
+
+    # ----------------------------------------------------------------------
+    # > INPUT MERGE LOGIC
+    # ----------------------------------------------------------------------
+
+    def __or__(self, other: "Input") -> "Input":
+        """
+        Merges two instances of `Input` into a new `Input`. Neither operand is modified.
+
+        Every component of the input is merged on its own terms:
+            - Simple keywords are combined, dropping duplicates. Their order is not preserved.
+            - Blocks are merged per ORCA block they model, through `Input.add_blocks()`. The values of `other` take precedence.
+              Every block is copied on the way in, so that the merged input shares no block
+              instance with either operand.
+            - Arbitrary strings are concatenated, those of `self` first, keeping duplicates.
+            - `ncores`, `memory` and `moinp` are taken from `other` if set, otherwise from `self`.
+              An `ncores` or `memory` of `0` counts as unset here.
+
+        If `other` is not an `Input`, `NotImplemented` is returned, so that Python fails the `|`
+        operation with a `TypeError`.
+
+        Parameters
+        ----------
+        other : Input
+            Instance of `Input` to be merged into `self`
+
+        Returns
+        -------
+        Input
+            New instance of `Input` with the simple keywords, blocks, arbitrary strings and
+            special input variables of `self` and `other`.
+        """
+        if not isinstance(other, Input):
+            return NotImplemented
+
+        # > Systematically handle all components of an Input object.
+        new_input = Input()
+
+        # > First simple keywords will be handled by merging the two lists of simple keywords, dropping duplicates
+        new_keyword_list = list(
+            set(
+                (self.simple_keywords if self.simple_keywords else [])
+                + (other.simple_keywords if other.simple_keywords else [])
+            )
+        )
+        new_input.add_simple_keywords(*new_keyword_list)
+
+        # > Next the blocks will be handled, since the Block already implements merge logic, the blocks will be iteratively merged based on name of block
+        # > Since add_blocks() already handles the merge case, we need only to iteratively add all the blocks in self followed by those in other
+        for blocks in (self.blocks, other.blocks):
+            for block in (blocks or {}).values():
+                new_input.add_blocks(block.model_copy(deep=True))
+
+        # > Next the arbitrary strings will be handled, here the list of strings will simply be merged.
+        new_arbit_strings_list = (self.arbitrary_strings if self.arbitrary_strings else []) + (
+            other.arbitrary_strings if other.arbitrary_strings else []
+        )
+        for arbit_string in new_arbit_strings_list:
+            new_input.add_arbitrary_string(arbit_string)
+
+        # > Finally the various special variables will be handled by giving precedence to the other Input object
+
+        new_input.ncores = other.ncores if other.ncores else self.ncores
+
+        new_input.memory = other.memory if other.memory else self.memory
+
+        new_input.moinp = other.moinp if other.moinp else self.moinp
+
+        return new_input

--- a/src/opi/input/core.py
+++ b/src/opi/input/core.py
@@ -320,6 +320,9 @@ class Input:
 
         The keywords are stored in the class attribute `_simple_keywords`.
 
+        Keywords are compared case-insensitively, so a keyword that only differs in case from an
+        already added one counts as a duplicate. The spelling of the first occurrence is kept.
+
         Parameters
         ----------
         *keywords : str | SimpleKeyword
@@ -388,7 +391,7 @@ class Input:
         for keyword in keywords:
             # > Convert string to simple keyword.
             if isinstance(keyword, str):
-                simple_keyword = SimpleKeyword(keyword.lower())
+                simple_keyword = SimpleKeyword(keyword)
             else:
                 simple_keyword = keyword
 
@@ -417,7 +420,7 @@ class Input:
         if not self._simple_keywords:
             return False
         if isinstance(keyword, str):
-            return SimpleKeyword(keyword.lower()) in self._simple_keywords
+            return SimpleKeyword(keyword) in self._simple_keywords
         else:
             return keyword in self._simple_keywords
 
@@ -458,7 +461,7 @@ class Input:
             If the simple keyword exists, or it was created, it is returned, else None is returned.
         """
         if isinstance(keyword, str):
-            simple_keyword: SimpleKeyword = SimpleKeyword(keyword.lower())
+            simple_keyword: SimpleKeyword = SimpleKeyword(keyword)
         else:
             simple_keyword = keyword
 
@@ -920,7 +923,8 @@ class Input:
         Merges two instances of `Input` into a new `Input`. Neither operand is modified.
 
         Every component of the input is merged on its own terms:
-            - Simple keywords are combined, dropping duplicates. Their order is not preserved.
+            - Simple keywords are concatenated, those of `self` first, dropping duplicates. The
+              order is preserved: the first occurrence of a keyword determines its position.
             - Blocks are merged per ORCA block they model, through `Input.add_blocks()`. The values of `other` take precedence.
               Every block is copied on the way in, so that the merged input shares no block
               instance with either operand.
@@ -948,14 +952,13 @@ class Input:
         # > Systematically handle all components of an Input object.
         new_input = Input()
 
-        # > First simple keywords will be handled by merging the two lists of simple keywords, dropping duplicates
-        new_keyword_list = list(
-            set(
-                (self.simple_keywords if self.simple_keywords else [])
-                + (other.simple_keywords if other.simple_keywords else [])
-            )
+        # > First simple keywords will be handled by concatenating the two lists of simple keywords,
+        # > those of `self` first. `add_simple_keywords()` drops duplicates, so the first occurrence
+        # > of a keyword determines its position.
+        new_input.add_simple_keywords(
+            *(self.simple_keywords if self.simple_keywords else []),
+            *(other.simple_keywords if other.simple_keywords else []),
         )
-        new_input.add_simple_keywords(*new_keyword_list)
 
         # > Next the blocks will be handled, since the Block already implements merge logic, the blocks will be iteratively merged based on name of block
         # > Since add_blocks() already handles the merge case, we need only to iteratively add all the blocks in self followed by those in other

--- a/src/opi/input/simple_keywords/base.py
+++ b/src/opi/input/simple_keywords/base.py
@@ -12,6 +12,10 @@ class SimpleKeyword:
     The public name is the name of the keyword that is used in the input file
     The keyword is the name of the keyword that is used in the ORCA input file
 
+    Two simple keywords compare equal if their keywords match case-insensitively, since
+    `format_orca()` lowercases the keyword and ORCA itself ignores the case. Hence, keywords
+    that only differ in case are duplicates of each other.
+
     Attributes
     ----------
     keyword: str
@@ -78,7 +82,7 @@ class SimpleKeyword:
         return self.keyword.lower()
 
     def __hash__(self) -> int:
-        return self.keyword.__hash__()
+        return self.keyword.lower().__hash__()
 
     def __str__(self) -> str:
         return self.format_orca()
@@ -86,4 +90,4 @@ class SimpleKeyword:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SimpleKeyword):
             return False
-        return self.keyword == other.keyword
+        return self.keyword.lower() == other.keyword.lower()

--- a/tests/unit/test_input_merge.py
+++ b/tests/unit/test_input_merge.py
@@ -24,8 +24,8 @@ covering each component that is merged:
 @pytest.mark.unit
 @pytest.mark.input
 def test_input_or_combines_simple_keywords_of_both_sides():
-    """Test for `Input.__or__()`: keywords added to only one side are all present in the merge.
-    The keywords are compared as a set, as `Input.__or__()` does not preserve their order."""
+    """Test for `Input.__or__()`: keywords added to only one side are all present in the merge,
+    in order, with those of the left-hand input first."""
     left = Input()
     left.add_simple_keywords(Dft.B3LYP)
     right = Input()
@@ -33,7 +33,7 @@ def test_input_or_combines_simple_keywords_of_both_sides():
 
     merged = left | right
 
-    assert set(merged.simple_keywords) == {Dft.B3LYP, BasisSet.DEF2_TZVP, Task.SP}
+    assert merged.simple_keywords == [Dft.B3LYP, BasisSet.DEF2_TZVP, Task.SP]
 
 
 @pytest.mark.unit
@@ -49,6 +49,27 @@ def test_input_or_drops_duplicate_simple_keywords():
 
     assert len(merged.simple_keywords) == 3
     assert set(merged.simple_keywords) == {Dft.B3LYP, Scf.TIGHTSCF, BasisSet.DEF2_TZVP}
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_preserves_simple_keyword_order():
+    """Test for `Input.__or__()`: the keywords keep the order in which they were added, those of
+    the left-hand input first. A duplicate keeps the position of its first occurrence, so a
+    keyword held by both sides stays at its left-hand position."""
+    left = Input()
+    left.add_simple_keywords(Task.SP, Dft.B3LYP)
+    right = Input()
+    right.add_simple_keywords(Scf.TIGHTSCF, Dft.B3LYP, BasisSet.DEF2_TZVP)
+
+    merged = left | right
+
+    assert merged.simple_keywords == [
+        Task.SP,
+        Dft.B3LYP,
+        Scf.TIGHTSCF,
+        BasisSet.DEF2_TZVP,
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_input_merge.py
+++ b/tests/unit/test_input_merge.py
@@ -1,0 +1,426 @@
+from pathlib import Path
+
+import pytest
+
+from opi.input import ArbitraryStringPos, Input
+from opi.input.blocks import Block, BlockMethod, BlockScf
+from opi.input.simple_keywords import BasisSet, Dft, Scf, Task
+
+"""
+This module contains tests for the merging of two `Input` objects through `Input.__or__()`,
+covering each component that is merged:
+- Simple keywords
+- Blocks
+- Arbitrary strings
+- The special input variables `ncores`, `memory` and `moinp`
+"""
+
+
+# ---------------------------------------------------------------------------
+# Simple keywords
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_combines_simple_keywords_of_both_sides():
+    """Test for `Input.__or__()`: keywords added to only one side are all present in the merge.
+    The keywords are compared as a set, as `Input.__or__()` does not preserve their order."""
+    left = Input()
+    left.add_simple_keywords(Dft.B3LYP)
+    right = Input()
+    right.add_simple_keywords(BasisSet.DEF2_TZVP, Task.SP)
+
+    merged = left | right
+
+    assert set(merged.simple_keywords) == {Dft.B3LYP, BasisSet.DEF2_TZVP, Task.SP}
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_drops_duplicate_simple_keywords():
+    """Test for `Input.__or__()`: a keyword held by both sides appears only once in the merge."""
+    left = Input()
+    left.add_simple_keywords(Dft.B3LYP, Scf.TIGHTSCF)
+    right = Input()
+    right.add_simple_keywords(Dft.B3LYP, BasisSet.DEF2_TZVP)
+
+    merged = left | right
+
+    assert len(merged.simple_keywords) == 3
+    assert set(merged.simple_keywords) == {Dft.B3LYP, Scf.TIGHTSCF, BasisSet.DEF2_TZVP}
+
+
+# ---------------------------------------------------------------------------
+# Blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_keeps_block_present_only_in_self():
+    """Test for `Input.__or__()`: a block that only the left operand holds is carried over."""
+    left = Input()
+    left.add_blocks(BlockScf(maxiter=300))
+    right = Input()
+
+    merged = left | right
+
+    assert set(merged.blocks) == {"scf"}
+    assert merged.get_block("scf").maxiter == 300
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_keeps_block_present_only_in_other():
+    """Test for `Input.__or__()`: a block that only the right operand holds is carried over, with
+    its own block class rather than as an arbitrary block."""
+    left = Input()
+    right = Input()
+    right.add_blocks(BlockScf(maxiter=125))
+
+    merged = left | right
+
+    assert set(merged.blocks) == {"scf"}
+    assert merged.get_block("scf").maxiter == 125
+    assert isinstance(merged.get_block("scf"), BlockScf)
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_merges_block_held_by_both_sides():
+    """Test for `Input.__or__()`: a block modelled by both sides is merged field-wise, with the
+    value of the right operand taking precedence on a conflict."""
+    left = Input()
+    left.add_blocks(BlockScf(maxiter=300, convergence="tight"))
+    right = Input()
+    right.add_blocks(BlockScf(maxiter=125))
+
+    merged = left | right
+
+    assert merged.get_block("scf").maxiter == 125
+    assert merged.get_block("scf").convergence == "tight"
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_keeps_disjoint_blocks_of_both_sides():
+    """Test for `Input.__or__()`: blocks modelling different ORCA blocks are kept side by side."""
+    left = Input()
+    left.add_blocks(BlockScf(maxiter=300))
+    right = Input()
+    right.add_blocks(BlockMethod(d3s6=0.64))
+
+    merged = left | right
+
+    assert set(merged.blocks) == {"scf", "method"}
+    assert merged.get_block("scf").maxiter == 300
+    assert merged.get_block("method").d3s6 == 0.64
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_merges_arbitrary_blocks_of_the_same_name():
+    """Test for `Input.__or__()`: arbitrary blocks are merged by the name they are given, combining
+    the options of both sides, with the option of the right operand winning a conflict."""
+    left = Input()
+    left.add_blocks(Block(name="arbit", values={"first": "1", "shared": "left"}))
+    right = Input()
+    right.add_blocks(Block(name="arbit", values={"second": "2", "shared": "right"}))
+
+    merged = left | right
+
+    assert set(merged.blocks) == {"arbit"}
+    assert merged.get_block("arbit").get_option("first") == "1"
+    assert merged.get_block("arbit").get_option("second") == "2"
+    assert merged.get_block("arbit").get_option("shared") == "right"
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_keeps_options_of_a_one_sided_arbitrary_block():
+    """Test for `Input.__or__()`: an arbitrary block held by only one side keeps its name and its
+    options through the copy, as both live on private attributes rather than pydantic fields."""
+    left = Input()
+    left.add_blocks(Block(name="solo", values={"only": "kept"}))
+    right = Input()
+
+    merged = left | right
+
+    assert merged.get_block("solo").name == "solo"
+    assert merged.get_block("solo").get_option("only") == "kept"
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_copies_a_one_sided_block():
+    """Test for `Input.__or__()`: a block that only one side holds is copied into the merge, so
+    that the merged input shares no block instance with either operand."""
+    left = Input()
+    left.add_blocks(BlockScf(maxiter=300))
+    right = Input()
+    right.add_blocks(BlockMethod(d3s6=0.64))
+
+    merged = left | right
+
+    assert merged.get_block("scf") is not left.get_block("scf")
+    assert merged.get_block("method") is not right.get_block("method")
+    assert merged.get_block("scf").maxiter == 300
+    assert merged.get_block("method").d3s6 == 0.64
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_does_not_mutate_a_one_sided_block_through_the_merge():
+    """Test for `Input.__or__()`: since a one-sided block is copied rather than shared, modifying
+    the block of the merged input leaves the block of the operand it came from untouched."""
+    left = Input()
+    left.add_blocks(BlockScf(maxiter=300))
+    right = Input()
+
+    merged = left | right
+    merged.get_block("scf").maxiter = 125
+
+    assert left.get_block("scf").maxiter == 300
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_merged_block_is_distinct_from_both_operands():
+    """Test for `Input.__or__()`: where both sides hold a block of the same name, the merge result
+    is a new instance and neither operand's block is mutated."""
+    left_block = BlockScf(maxiter=300)
+    right_block = BlockScf(maxiter=125)
+    left = Input()
+    left.add_blocks(left_block)
+    right = Input()
+    right.add_blocks(right_block)
+
+    merged = left | right
+
+    assert merged.get_block("scf") is not left_block
+    assert merged.get_block("scf") is not right_block
+    assert left_block.maxiter == 300
+    assert right_block.maxiter == 125
+
+
+# ---------------------------------------------------------------------------
+# Arbitrary strings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_concatenates_arbitrary_strings_with_self_first():
+    """Test for `Input.__or__()`: the arbitrary strings of both sides are concatenated, those of
+    the left operand first."""
+    left = Input()
+    left.add_arbitrary_string("left string")
+    right = Input()
+    right.add_arbitrary_string("right string")
+
+    merged = left | right
+
+    assert [str(string) for string in merged.arbitrary_strings] == ["left string", "right string"]
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_keeps_duplicate_arbitrary_strings():
+    """Test for `Input.__or__()`: unlike simple keywords, arbitrary strings are not de-duplicated,
+    as the same string may legitimately be needed twice."""
+    left = Input()
+    left.add_arbitrary_string("same string")
+    right = Input()
+    right.add_arbitrary_string("same string")
+
+    merged = left | right
+
+    assert [str(string) for string in merged.arbitrary_strings] == ["same string", "same string"]
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_preserves_arbitrary_string_position():
+    """Test for `Input.__or__()`: an arbitrary string is carried over with its position, which is
+    not part of its equality and could therefore be lost silently."""
+    left = Input()
+    left.add_arbitrary_string("top string", pos=ArbitraryStringPos.TOP)
+    right = Input()
+    right.add_arbitrary_string("bottom string", pos=ArbitraryStringPos.BOTTOM)
+
+    merged = left | right
+
+    positions = {str(string): string.pos for string in merged.arbitrary_strings}
+    assert positions["top string"] is ArbitraryStringPos.TOP
+    assert positions["bottom string"] is ArbitraryStringPos.BOTTOM
+
+
+# ---------------------------------------------------------------------------
+# Special input variables
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_other_special_variables_take_precedence():
+    """Test for `Input.__or__()`: where both sides set `ncores` and `memory`, the values of the
+    right operand are kept."""
+    left = Input()
+    left.ncores = 4
+    left.memory = 2000
+    right = Input()
+    right.ncores = 8
+    right.memory = 4000
+
+    merged = left | right
+
+    assert merged.ncores == 8
+    assert merged.memory == 4000
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_falls_back_to_self_special_variables():
+    """Test for `Input.__or__()`: where the right operand leaves `ncores` and `memory` unset, the
+    values of the left operand are kept."""
+    left = Input()
+    left.ncores = 4
+    left.memory = 2000
+    right = Input()
+
+    merged = left | right
+
+    assert merged.ncores == 4
+    assert merged.memory == 2000
+
+
+@pytest.mark.unit
+@pytest.mark.input
+@pytest.mark.parametrize("variable", ["ncores", "memory"])
+def test_input_or_treats_zero_as_unset(variable: str):
+    """Test for `Input.__or__()`: `ncores` and `memory` are carried over on truthiness, so a `0` on
+    the right operand falls back to the value of the left one, as the docstring states."""
+    left = Input()
+    setattr(left, variable, 4)
+    right = Input()
+    setattr(right, variable, 0)
+
+    merged = left | right
+
+    assert getattr(merged, variable) == 4
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_moinp_of_other_takes_precedence(tmp_path: Path):
+    """Test for `Input.__or__()`: `moinp` follows the same precedence as the other special input
+    variables. The setter requires an existing file, hence the two temporary ones."""
+    left_gbw = tmp_path / "left.gbw"
+    left_gbw.touch()
+    right_gbw = tmp_path / "right.gbw"
+    right_gbw.touch()
+    left = Input()
+    left.moinp = left_gbw
+    right = Input()
+    right.moinp = right_gbw
+
+    merged = left | right
+
+    assert merged.moinp == right_gbw.resolve()
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_falls_back_to_self_moinp(tmp_path: Path):
+    """Test for `Input.__or__()`: `moinp` of the left operand is kept when the right is unset."""
+    left_gbw = tmp_path / "left.gbw"
+    left_gbw.touch()
+    left = Input()
+    left.moinp = left_gbw
+    right = Input()
+
+    merged = left | right
+
+    assert merged.moinp == left_gbw.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Result and operands as a whole
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_returns_new_instance_without_mutating_operands():
+    """Test for `Input.__or__()`: the merge is returned as a new `Input` and neither operand gains
+    the keywords, blocks, arbitrary strings or special variables of the other."""
+    left = Input()
+    left.add_simple_keywords(Dft.B3LYP)
+    left.add_blocks(BlockScf(maxiter=300))
+    left.add_arbitrary_string("left string")
+    left.ncores = 4
+    right = Input()
+    right.add_simple_keywords(BasisSet.DEF2_TZVP)
+    right.add_blocks(BlockMethod(d3s6=0.64))
+    right.add_arbitrary_string("right string")
+    right.ncores = 8
+
+    merged = left | right
+
+    assert merged is not left
+    assert merged is not right
+    assert left.simple_keywords == [Dft.B3LYP]
+    assert set(left.blocks) == {"scf"}
+    assert [str(string) for string in left.arbitrary_strings] == ["left string"]
+    assert left.ncores == 4
+    assert right.simple_keywords == [BasisSet.DEF2_TZVP]
+    assert set(right.blocks) == {"method"}
+    assert [str(string) for string in right.arbitrary_strings] == ["right string"]
+    assert right.ncores == 8
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_of_two_empty_inputs_is_empty():
+    """Test for `Input.__or__()`: merging two untouched inputs yields an untouched input."""
+    merged = Input() | Input()
+
+    assert merged.simple_keywords == []
+    assert merged.blocks == {}
+    assert merged.arbitrary_strings == []
+    assert merged.ncores is None
+    assert merged.memory is None
+    assert merged.moinp is None
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_input_or_result_is_writable_to_orca_input():
+    """Test for `Input.__or__()`: the merged input formats itself for the ORCA input file, carrying
+    the keywords, blocks and arbitrary strings of both sides into it."""
+    left = Input()
+    left.add_simple_keywords(Dft.B3LYP)
+    left.add_blocks(BlockScf(maxiter=300))
+    right = Input()
+    right.add_simple_keywords(BasisSet.DEF2_TZVP)
+    right.add_blocks(Block(name="arbit", values={"opt": "7"}))
+    right.add_arbitrary_string("right string")
+
+    formatted = (left | right).format_before_coords()
+
+    assert "b3lyp" in formatted
+    assert "def2-tzvp" in formatted
+    assert "maxiter 300" in formatted
+    assert "%arbit" in formatted
+    assert "right string" in formatted
+
+
+@pytest.mark.unit
+@pytest.mark.input
+@pytest.mark.parametrize("other", [None, 5, "scf", BlockScf(maxiter=300)])
+def test_input_or_rejects_non_input(other: object):
+    """Test for `Input.__or__()`: merging with something that is not an `Input` returns
+    `NotImplemented`, so that Python fails the `|` operation with a `TypeError`."""
+    with pytest.raises(TypeError):
+        Input() | other

--- a/tests/unit/test_input_simple_keywords.py
+++ b/tests/unit/test_input_simple_keywords.py
@@ -135,3 +135,56 @@ def test_has_simple_keyword(calc: Calculator, keywords_tuple: tuple):
     """Test `Input.has_simple_keywords()` with different combinations of keywords and expected values."""
     keyword, result = keywords_tuple
     assert calc.input.has_simple_keywords(*keyword) == result
+
+
+@pytest.mark.unit
+@pytest.mark.input
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        pytest.param("TightSCF", "tightscf", id="mixed_vs_lower"),
+        pytest.param("PBE", "pbe", id="upper_vs_lower"),
+        pytest.param("Def2-SVP", "DEF2-svp", id="mixed_vs_mixed"),
+    ],
+)
+def test_simple_keyword_eq_is_case_insensitive(left: str, right: str):
+    """Test that two `SimpleKeyword` objects that only differ in case compare equal and hash
+    equally, matching `SimpleKeyword.format_orca()`, which lowercases the keyword."""
+    assert SimpleKeyword(left) == SimpleKeyword(right)
+    assert hash(SimpleKeyword(left)) == hash(SimpleKeyword(right))
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_add_simple_keywords_drops_case_insensitive_duplicate(empty_calc: Calculator):
+    """Test `Input.add_simple_keywords()`: a keyword that only differs in case from an already
+    added one is a duplicate and is dropped, keeping the spelling of the first occurrence."""
+    empty_calc.input.add_simple_keywords("TightSCF")
+    empty_calc.input.add_simple_keywords("tightscf", "TIGHTSCF")
+
+    assert empty_calc.input.simple_keywords == [SimpleKeyword("TightSCF")]
+    assert empty_calc.input.simple_keywords[0].keyword == "TightSCF"
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_add_simple_keywords_strict_raises_on_case_insensitive_duplicate(
+    empty_calc: Calculator,
+):
+    """Test `Input.add_simple_keywords()` with `strict=True`: a keyword that only differs in case
+    from an already added one raises a `ValueError`."""
+    empty_calc.input.add_simple_keywords("TightSCF")
+
+    with pytest.raises(ValueError):
+        empty_calc.input.add_simple_keywords("tightscf", strict=True)
+
+
+@pytest.mark.unit
+@pytest.mark.input
+def test_remove_simple_keywords_is_case_insensitive(empty_calc: Calculator):
+    """Test `Input.remove_simple_keywords()`: a keyword added in mixed case can be removed
+    through any other case spelling."""
+    empty_calc.input.add_simple_keywords("TightSCF")
+    empty_calc.input.remove_simple_keywords("TIGHTSCF")
+
+    assert empty_calc.input.simple_keywords == []


### PR DESCRIPTION
## Closes Issues
Closes #277

## Description
- Allows the merging of two `Input` objects.
- Simple keywords will be merged with duplicates dropped, while blocks will be merged according to existing block merge logic.
- Arbitrary strings will follow the same logic as simple keywords, with both lists of arbitrary strings being combined.

---

## Release Notes

### Added 

- Add merge logic for two `Input` objects, via `Input.__or__()`: simple keywords are combined without duplicates, blocks that model the same ORCA block are merged, arbitrary strings are concatenated, and `ncores`, `memory` and `moinp` are taken from the right-hand input if set. The right-hand input takes precedence throughout, blocks are copied into the result, and neither operand is modified.(#288)


### Changed 

- `Input.add_arbitrary_string()` now also accepts an `ArbitraryString` instance next to a plain `str`, so that an arbitrary string can be added together with the position it carries. (#288)
- `SimpleKeyword` now compares equal case-insensitively, matching `SimpleKeyword.format_orca()`, which lowercases the keyword, and ORCA itself, which ignores the case. Hence keywords that only differ in case count as duplicates of each other in `Input.add_simple_keywords()`, `Input.remove_simple_keywords()`, `Input.has_simple_keyword()` and `Input.get_simple_keyword()`. (#288)


